### PR TITLE
823: Fixing error message when TPP is fetching a consent that it does not own

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/ConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/ConsentService.java
@@ -64,19 +64,15 @@ public class ConsentService implements ConsentServiceInterface {
         log.debug("=> The client id: '{}'", clientId);
 
         JsonObject consentDetails = request(consentRequest.getIntentId(), GET, null);
-        String errorMessage;
         if (consentDetails == null) {
-            errorMessage = String.format("The PISP/AISP '%s' is referencing a consent detailsRequest '%s' that doesn't exist", clientId, intentId);
-            log.error(errorMessage);
-            throw new ExceptionClient(consentRequest, ErrorType.NOT_FOUND, errorMessage);
+            log.error("TPP: {} is trying to access consent: {} that does not exist", clientId, intentId);
+            throw new ExceptionClient(consentRequest, ErrorType.NOT_FOUND, "The consent: " + intentId + " does not exist");
         }
 
-        // Verify the PISP/AISP is the same than the one that created this consent ^
+        // Verify the PISP/AISP is the same as the one that created this consent
         if (!clientId.equals(consentDetails.get("oauth2ClientId").getAsString())) {
-            errorMessage = String.format("The PISP/AISP '%S' created the consent detailsRequest '%S' but it's PISP/AISP '%s' that is trying to get" +
-                    " consent for it.", consentDetails.get("oauth2ClientId"), intentId, clientId);
-            log.error(errorMessage);
-            throw new ExceptionClient(consentRequest, ErrorType.INVALID_REQUEST, errorMessage);
+            log.error("TPP: {} is trying to access consent: {} that it is not authorised to access", clientId, intentId);
+            throw new ExceptionClient(consentRequest, ErrorType.INVALID_REQUEST, "You are not authorised to access consent: " + intentId);
         }
 
         return consentDetails;

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/exception/RcsErrorService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/exception/RcsErrorService.java
@@ -111,7 +111,7 @@ public class RcsErrorService {
                     .fromHttpUrl(redirectURL)
                     .fragment("error=" + errorType.getErrorCode() + "&state=" + state +
                             "&error_description=" + String.format(errorDescription) +
-                            "error_uri=" + errorType.getErrorUri(errorType.getInternalCode()))
+                            "&error_uri=" + errorType.getErrorUri(errorType.getInternalCode()))
                     .encode()
                     .build();
 


### PR DESCRIPTION
The previous error message was leaking the client_id of the TPP that owns the consent.

TPPs should have no knowledge of other TPP client_ids.

Cleaning up error message and logging for consent does not exist case.

Fixing bug in redirect uri; adding missing param separator.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/823