### PR TITLE
880: Removing dependency secure-api-gateway-common-cors and configuration

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           env:
-          - name: EXPECTED_ORIGIN_ENDS
-            value: {{ .Values.deployment.cors.originEnds }}
           - name: CONSENT_REPO_HOST
             valueFrom:
               configMapKeyRef:

--- a/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/values.yaml
@@ -17,9 +17,6 @@ deployment:
   server:
     port: 8080
 
-  cors:
-    originEnds: localhost
-
   java:
     opts: -XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -agentlib:jdwp=transport=dt_socket,address=*:9091,server=y,suspend=n
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
 
     <properties>
         <uk.bom.version>0.9.0-SNAPSHOT</uk.bom.version>
-        <common.cors.version>0.9.0-SNAPSHOT</common.cors.version>
     </properties>
 
     <dependencyManagement>
@@ -54,11 +53,6 @@
                 <version>${uk.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.forgerock.sapi.gateway</groupId>
-                <artifactId>secure-api-gateway-common-cors</artifactId>
-                <version>${common.cors.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/secure-api-gateway-ob-uk-rcs-server/docker/config/securebanking-openbanking-uk-rcs-docker.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/docker/config/securebanking-openbanking-uk-rcs-docker.yml
@@ -16,18 +16,6 @@
 
 ### Spring Configuration for securebanking-openbanking-uk-rcs running in Docker
 
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-${library-name}' libraries
-  cors: # library name
-#    allowed_origins: # CORS list allowed domains, to check if the origin header domain ends with any allowed origin.
-#      - "*" # Allow all origins
-#      - localhost
-#      - forgerock.financial # valid for *.forgerock.financial
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token # CORS allowed headers
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH # Allowed methods for preflight request
-    allowed_credentials: false #true # Credentials accepted, default value true
-    max_age: 8000 #3600 # Expiration time of preflight request, default value 3600
-
 logging:
   level:
     com.forgerock: DEBUG

--- a/secure-api-gateway-ob-uk-rcs-server/docker/config/securebanking-openbanking-uk-rs-docker.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/docker/config/securebanking-openbanking-uk-rs-docker.yml
@@ -16,18 +16,6 @@
 
 ### Spring Configuration for securebanking-openbanking-uk-rs-simulator running in Docker
 
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-${library-name}' libraries
-  cors: # library name
-#    allowed_origins: # CORS list allowed domains, to check if the origin header domain ends with any allowed origin.
-#      - "*" # allow all origins
-#      - localhost
-#      - forgerock.financial # valid for *.forgerock.financial
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token # CORS allowed headers
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH # Allowed methods for preflight request
-    allowed_credentials: false #true # Credentials accepted, default value true
-    max_age: 8000 #3600 # Expiration time of preflight request, default value 3600
-
 logging:
   level:
     com.forgerock: DEBUG

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -52,11 +52,6 @@
         <!-- ForgeRock dependencies -->
         <dependency>
             <groupId>com.forgerock.sapi.gateway</groupId>
-            <artifactId>secure-api-gateway-common-cors</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.forgerock.sapi.gateway</groupId>
             <artifactId>secure-api-gateway-ob-uk-rcs-cloud-client</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/RCSServerApplication.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/RCSServerApplication.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.ComponentScan;
 
 @ComponentScan(basePackages =
         {
-                "com.forgerock.sapi.gateway.common.cors",
                 "com.forgerock.sapi.gateway.ob.uk.rcs"
         }
 )

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -27,15 +27,3 @@ springfox:
     swagger:
       v2:
         path: /api-docs
-
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-*' libraries
-  cors: # library name
-#    allowed_origins:
-#      - "*"
-#      - localhost
-#      - forgerock.financial # valid for *.forgerock.financial
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH
-    allowed_credentials: true # default value true
-    max_age: 3600 # default value 3600

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
@@ -58,18 +58,6 @@ rs:
 #  internal-port: 8081
 #  base-url: https://rs-simulator:${rs.internal-port}
 
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-*' libraries
-  cors: # library name
-    allowed_origins:
-      - localhost
-      - forgerock.financial # valid for *.forgerock.financial
-      - domain4test.com # don't delete it!
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH
-    allowed_credentials: true # default value true
-    max_age: 3600 # default value 3600
-
 # Swagger Documentation Specification properties
 swagger:
   title: Secure API Gateway


### PR DESCRIPTION
- CORS support is not needed for RCS
- Access to RCS UI and RCS backend must go through the gateway
  - From the browser perspective they are calling the same host

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/880