### PR TITLE
749: Supplying Consent Repo and RS API URIs via platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ In this section we will discuss the config that is deployment specific, this con
 
 | Property                                  | Description                                                         |
 |-------------------------------------------|---------------------------------------------------------------------|
-| consent.repo.host                         | The host that is running the Consent Repo                           |
-| rs.internal.svc                           | The internal service address of the Resource Server (RS)            |
+| consent.repo.uri                          | Base URI of the Consent Repo API                                    |
+| rs.api.uri                                | Base URI of the RS API                                              |
 | rcs.consent.response.jwt.signingKeyId     | kid of the key used to sign JWTs produced by the application        |
 | rcs.consent.response.jwt.privateKeyPath   | Path to the RSA private key PEM file that is used to sign the JWTs  |
 | rcs.consent.response.jwt.issuer           | Value to set as the `iss` claim in JWTs produced by the application |

--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -54,16 +54,16 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           env:
-          - name: CONSENT_REPO_HOST
+          - name: CONSENT_REPO_URI
             valueFrom:
               configMapKeyRef:
                 name: securebanking-platform-config
-                key: IG_INTERNAL_SVC
-          - name: RS_INTERNAL_SVC
+                key: RCS_CONSENT_REPO_URI
+          - name: RS_API_URI
             valueFrom:
               configMapKeyRef:
                 name: securebanking-platform-config
-                key: RS_INTERNAL_SVC
+                key: RS_API_URI
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_PROFILES_ACTIVE

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/ConsentRepoConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/ConsentRepoConfiguration.java
@@ -17,6 +17,7 @@ package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration;
 
 import lombok.Data;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.LinkedCaseInsensitiveMap;
@@ -24,15 +25,13 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
 import java.util.Map;
 
 @Configuration
-@ConfigurationProperties(prefix = "consent-repo.client")
+@ConfigurationProperties(prefix = "consent.repo")
 @Data
 public class ConsentRepoConfiguration {
 
-    private String host;
+    @Value("${consent.repo.uri}")
+    private String baseUri;
 
-    private int port;
-
-    private String scheme;
     /*
      * Spring maps the properties, the keys from file will be the map keys
      * @see: application-test.yml
@@ -45,6 +44,6 @@ public class ConsentRepoConfiguration {
     private Map<String, String> contextsUser = new LinkedCaseInsensitiveMap<>();
 
     public String getConsentRepoBaseUri() {
-        return new StringBuilder(128).append(scheme).append("://").append(host).append(':').append(port).toString();
+        return baseUri;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/ConsentRepoConfigurationTest.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/ConsentRepoConfigurationTest.java
@@ -59,8 +59,6 @@ public class ConsentRepoConfigurationTest {
         assertThat(consentRepoConfiguration.getContextsRepoConsent()).isNotNull();
         assertThat(consentRepoConfiguration.getContextsApiClient()).isNotNull();
         assertThat(consentRepoConfiguration.getContextsUser()).isNotNull();
-        assertThat(consentRepoConfiguration.getScheme()).isNotNull();
-        assertThat(consentRepoConfiguration.getScheme()).isEqualTo("http");
     }
 
     @Test

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/resources/application-test.yml
@@ -1,8 +1,6 @@
-consent-repo:
-  client:
-    scheme: http
-    host: ${CONSENT_REPO_HOST:ig}
-    port: 80
+consent:
+  repo:
+    uri: http://ig:80
     contexts_api_client:
       get: /repo/apiclients/@ClientId@
       put: /repo/apiclients/@ClientId@

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsBackofficeConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsBackofficeConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
 import java.util.Map;
 
 @Configuration
-@ConfigurationProperties(prefix = "rs.backoffice.uris")
+@ConfigurationProperties(prefix = "rs.api.backoffice.uris")
 @Data
 public class RsBackofficeConfiguration {
     private Map<String, String> accounts = new LinkedCaseInsensitiveMap<>();

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsConfiguration.java
@@ -15,16 +15,19 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration;
 
-import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
-import java.net.URI;
-
 @Configuration
-@Data
 public class RsConfiguration {
 
-    @Value("${rs.baseUri}")
-    private String baseUri;
+    private final String baseUri;
+
+    public RsConfiguration(@Value("${rs.api.uri}") String baseUri) {
+        this.baseUri = baseUri;
+    }
+
+    public String getBaseUri() {
+        return baseUri;
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -22,11 +22,8 @@ api:
 
 # Configuration for calling the Consent Repository
 # See: com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.ConsentRepoConfiguration
-consent-repo:
-  client:
-    scheme: http
-    host: ${consent.repo.host}
-    port: 80
+consent:
+  repo:
     # Context to build the URI to make a request against the repository endpoint to obtain the client object by clientId
     contexts_api_client:
       get: /repo/apiclients/@ClientId@
@@ -50,17 +47,17 @@ consent-repo:
 # Configuration for calling the RS backoffice API
 # See: com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsBackofficeConfiguration
 rs:
-  baseUri: http://${rs.internal.svc}:8080
-  backoffice:
-    uris:
-      accounts:
-        # Context endpoint to find accounts user by userId
-        findUserById: /backoffice/accounts/search/findByUserId
-        # Context endpoint to find account identifier by userId and account identifiers (name, identification and scheme name)
-        findByAccountIdentifiers: /backoffice/accounts/search/findByAccountIdentifiers
-      domestic-payments:
-        # Context endpoint to find payment user by userId
-        findUserById: /backoffice/domestic-payments/search/findByUserId
+  api:
+    backoffice:
+      uris:
+        accounts:
+          # Context endpoint to find accounts user by userId
+          findUserById: /backoffice/accounts/search/findByUserId
+          # Context endpoint to find account identifier by userId and account identifiers (name, identification and scheme name)
+          findByAccountIdentifiers: /backoffice/accounts/search/findByAccountIdentifiers
+        domestic-payments:
+          # Context endpoint to find payment user by userId
+          findUserById: /backoffice/domestic-payments/search/findByUserId
 
 #
 # Deployment Specific configuration
@@ -70,14 +67,14 @@ rs:
 # Consent Repo Configuration
 #consent:
 #  repo:
-#    # hostname for the consent repo API endpoints
-#    host:
+#    # Connection string to the Consent Repo base URI
+#    uri:
 #
 # Resource Server Configuration
 #rs:
-#  internal:
-#    # Name of the internal k8s svc used to access the rs
-#    svc:
+#  api:
+#    # Connection string to the RS API base URI
+#    uri:
 #
 # RCS Consent signing configuration
 # See: com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RcsApplicationConfiguration.rcsJwtSigner

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
@@ -1,8 +1,8 @@
 # Spring config for "test" profile
 # This config extends/overrides config in the default profile (file: src/main/resources/application.yml)
 rs:
-  internal:
-    svc: localhost
+  api:
+    uri: http://localhost:8080
 
 rcs:
   consent:

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
@@ -4,6 +4,10 @@ rs:
   api:
     uri: http://localhost:8080
 
+consent:
+  repo:
+    uri: http://ig:80
+
 rcs:
   consent:
     response:


### PR DESCRIPTION
Connection URIs for Consent Repo and RS API are now supplied via the platform config.

Switching to supply the base URI for the API, which removes any assumptions about using k8s internal services (which the previous spring config was doing).

https://github.com/SecureApiGateway/SecureApiGateway/issues/749