### PR TITLE
812: release actions docker workflow fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
   release_docker:
     name: Call publish docker
-    needs: [ release_prepare ]
+    needs: [ release_prepare, release_java ]
     uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-docker.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
@@ -57,7 +57,7 @@ jobs:
 
   release_helm:
     name: Call publish helm
-    needs: [ release_prepare ]
+    needs: [ release_prepare, release_java ]
     uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-helm.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ verify: clean
 	mvn verify
 
 docker: clean
-	mvn install package dockerfile:build dockerfile:push -DskipTests -DskipITs -Dtag=${tag} \
+	mvn install dockerfile:build dockerfile:push -DskipTests -DskipITs -Dtag=${tag} \
 	  -DgcrRepo=${repo} --file secure-api-gateway-ob-uk-rcs-server/pom.xml
 
 package_helm:


### PR DESCRIPTION
The java artifact needs to be published before docker and helm chart to resolve properly the dependencies

- Updated make file
- Updated release caller workflow

Issue: https://github.com/secureapigateway/secureapigateway/issues/812