### PR TITLE
889: Configure docker dependabot checking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directory: "/secure-api-gateway-ob-uk-rcs-server/docker/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This was looking in the wrong directory for the Dockerfile

Issue: https://github.com/secureapigateway/secureapigateway/issues/889