### PR TITLE
915: Renaming FilePaymentConsentDetails initiation field to filePayment

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/FilePaymentConsentDetails.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/FilePaymentConsentDetails.java
@@ -36,7 +36,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 public class FilePaymentConsentDetails extends PaymentsConsentDetails {
 
-    private FRWriteFileDataInitiation initiation;
+    private FRWriteFileDataInitiation filePayment;
     private FRAmount charges;
     private DateTime expiredDate;
     private String fileReference;
@@ -48,7 +48,7 @@ public class FilePaymentConsentDetails extends PaymentsConsentDetails {
 
     @Override
     public FRAccountIdentifier getDebtorAccount() {
-        return initiation.getDebtorAccount();
+        return filePayment.getDebtorAccount();
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/FilePaymentConsentDetailsFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/FilePaymentConsentDetailsFactory.java
@@ -53,7 +53,7 @@ public class FilePaymentConsentDetailsFactory implements ConsentDetailsFactory<F
 
                 if (JsonUtilValidation.isNotNull(data.get(INITIATION))) {
                     JsonObject initiation = data.getAsJsonObject(INITIATION);
-                    details.setInitiation(decodeDataInitiation(initiation));
+                    details.setFilePayment(decodeDataInitiation(initiation));
 
                     if (JsonUtilValidation.isNotNull(data.get(CHARGES))) {
                         details.setCharges(decodeCharges(data.getAsJsonArray(CHARGES)));


### PR DESCRIPTION
The RCS UI codebase is expecting a filePayment field in the details response. Reverting the initiation field name back to filePayment.

The UI code has a single object modelling all consent details, therefore we cannot use the initiation field for file data as it does not match the initiation schema of the other payments.

In the future we may want to consider modelling the different consent types in the UI, rather than having a single type: ApiResponses.ConsentDetailsResponse

https://github.com/SecureApiGateway/SecureApiGateway/issues/915