### PR TITLE
925: Adding creditorAccount to payment details initiation objects

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/DomesticVrpPaymentConsentDetailsFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/DomesticVrpPaymentConsentDetailsFactory.java
@@ -16,8 +16,8 @@
 package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder.FRAccountIdentifierDecoder;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.json.utils.JsonUtilValidation;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRWriteDomesticVrpDataInitiation;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.IntentType;
@@ -46,6 +46,12 @@ import static java.util.Objects.requireNonNull;
 @Slf4j
 @Component
 public class DomesticVrpPaymentConsentDetailsFactory implements ConsentDetailsFactory<DomesticVrpPaymentConsentDetails> {
+
+    private final FRAccountIdentifierDecoder accountIdentifierDecoder;
+
+    public DomesticVrpPaymentConsentDetailsFactory(FRAccountIdentifierDecoder accountIdentifierDecoder) {
+        this.accountIdentifierDecoder = accountIdentifierDecoder;
+    }
 
     @Override
     public DomesticVrpPaymentConsentDetails decode(JsonObject json) {
@@ -83,34 +89,10 @@ public class DomesticVrpPaymentConsentDetailsFactory implements ConsentDetailsFa
         log.debug("{}.{}.{}: {}", OB_INTENT_OBJECT, DATA, INITIATION, initiation);
         FRWriteDomesticVrpDataInitiation vrpDataInitiation = new FRWriteDomesticVrpDataInitiation();
         if (JsonUtilValidation.isNotNull(initiation.get(DEBTOR_ACCOUNT))) {
-            JsonObject debtorAccount = initiation.getAsJsonObject(DEBTOR_ACCOUNT);
-            vrpDataInitiation.setDebtorAccount(
-                    FRAccountIdentifier.builder()
-                            .identification(debtorAccount.get(IDENTIFICATION).getAsString())
-                            .name(debtorAccount.get(NAME).getAsString())
-                            .schemeName(debtorAccount.get(SCHEME_NAME).getAsString())
-                            .secondaryIdentification(
-                                    JsonUtilValidation.isNotNull(debtorAccount.get(SECONDARY_IDENTIFICATION)) ?
-                                            debtorAccount.get(SECONDARY_IDENTIFICATION).getAsString() :
-                                            null
-                            )
-                            .build()
-            );
+            vrpDataInitiation.setDebtorAccount(accountIdentifierDecoder.decode(initiation.getAsJsonObject(DEBTOR_ACCOUNT)));
         }
         if (JsonUtilValidation.isNotNull(initiation.get(CREDITOR_ACCOUNT))) {
-            JsonObject creditorAccount = initiation.getAsJsonObject(CREDITOR_ACCOUNT);
-            vrpDataInitiation.setCreditorAccount(
-                    FRAccountIdentifier.builder()
-                            .identification(creditorAccount.get(IDENTIFICATION).getAsString())
-                            .name(creditorAccount.get(NAME).getAsString())
-                            .schemeName(creditorAccount.get(SCHEME_NAME).getAsString())
-                            .secondaryIdentification(
-                                    JsonUtilValidation.isNotNull(creditorAccount.get(SECONDARY_IDENTIFICATION)) ?
-                                            creditorAccount.get(SECONDARY_IDENTIFICATION).getAsString() :
-                                            null
-                            )
-                            .build()
-            );
+            vrpDataInitiation.setCreditorAccount(accountIdentifierDecoder.decode(initiation.getAsJsonObject(CREDITOR_ACCOUNT)));
         }
 
         if (JsonUtilValidation.isNotNull(initiation.get(REMITTANCE_INFORMATION))) {

--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/FRAccountIdentifierDecoder.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/FRAccountIdentifierDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder;
+
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.IDENTIFICATION;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.NAME;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.SCHEME_NAME;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.SECONDARY_IDENTIFICATION;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.json.utils.JsonUtilValidation.isNotNull;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Decoder of FRAccountIdentifier objects
+ */
+@Component
+public class FRAccountIdentifierDecoder implements GsonDecoder<FRAccountIdentifier> {
+
+    @Override
+    public FRAccountIdentifier decode(JsonElement jsonElement) {
+        Objects.requireNonNull(jsonElement, "jsonElement must be supplied");
+        final JsonObject jsonObject = jsonElement.getAsJsonObject();
+        return FRAccountIdentifier.builder()
+                .identification(jsonObject.get(IDENTIFICATION).getAsString())
+                .name(jsonObject.get(NAME).getAsString())
+                .schemeName(jsonObject.get(SCHEME_NAME).getAsString())
+                .secondaryIdentification(isNotNull(jsonObject.get(SECONDARY_IDENTIFICATION)) ?
+                        jsonObject.get(SECONDARY_IDENTIFICATION).getAsString() :
+                        null)
+                .build();
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/GsonDecoder.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/GsonDecoder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder;
+
+import com.google.gson.JsonElement;
+
+/**
+ * Decoder which can transform a Gson representation of Json into an Object
+ *
+ * @param <T> The type of the Object that this decoder produces.
+ */
+public interface GsonDecoder<T> {
+
+    T decode(JsonElement jsonElement);
+
+}

--- a/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/ConsentDetailsFactoryProviderTest.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/ConsentDetailsFactoryProviderTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details;
 
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder.FRAccountIdentifierDecoder;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.IntentType;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,7 +47,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
         FundsConfirmationConsentDetailsFactory.class,
         InternationalPaymentConsentDetailsFactory.class,
         InternationalScheduledPaymentConsentDetailsFactory.class,
-        InternationalStandingOrderConsentDetailsFactory.class
+        InternationalStandingOrderConsentDetailsFactory.class,
+        FRAccountIdentifierDecoder.class
 })
 public class ConsentDetailsFactoryProviderTest {
     @Autowired

--- a/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/ConsentDetailsFactoryTest.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/ConsentDetailsFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details;
 
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder.FRAccountIdentifierDecoder;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.IntentType;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants;
@@ -57,7 +58,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
         InternationalPaymentConsentDetailsFactory.class,
         InternationalScheduledPaymentConsentDetailsFactory.class,
         InternationalStandingOrderConsentDetailsFactory.class,
-        FilePaymentConsentDetailsFactory.class
+        FilePaymentConsentDetailsFactory.class,
+        FRAccountIdentifierDecoder.class
 })
 public class ConsentDetailsFactoryTest {
 

--- a/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/FRAccountIdentifierDecoderTest.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/decoder/FRAccountIdentifierDecoderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder;
+
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.IDENTIFICATION;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.NAME;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.SCHEME_NAME;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetailsConstants.Intent.Members.SECONDARY_IDENTIFICATION;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+class FRAccountIdentifierDecoderTest {
+
+    private final FRAccountIdentifierDecoder decoder = new FRAccountIdentifierDecoder();
+
+    @Test
+    void failsIfInputNotJsonObject() {
+        final NullPointerException nullPointerException = assertThrows(NullPointerException.class, () -> decoder.decode(null));
+        assertEquals("jsonElement must be supplied", nullPointerException.getMessage());
+        final IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> decoder.decode(new JsonArray()));
+        assertEquals("Not a JSON Object: []", illegalStateException.getMessage());
+    }
+
+    @Test
+    void decodesValidObject() {
+        final String expectedIdentification = "identification123";
+        final String expectedName = "Current Account";
+        final String expectedSchema = "Schema XYZ";
+        final String expectedSecondaryId = "secondaryId123";
+
+        final JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(IDENTIFICATION, expectedIdentification);
+        jsonObject.addProperty(NAME, expectedName);
+        jsonObject.addProperty(SCHEME_NAME, expectedSchema);
+        jsonObject.addProperty(SECONDARY_IDENTIFICATION, expectedSecondaryId);
+
+        validateFRAccountIdentifier(decoder.decode(jsonObject), expectedIdentification, expectedName, expectedSchema, expectedSecondaryId);
+
+        // Secondary identification field is optional
+        jsonObject.remove(SECONDARY_IDENTIFICATION);
+        validateFRAccountIdentifier(decoder.decode(jsonObject), expectedIdentification, expectedName, expectedSchema, null);
+    }
+
+    private static void validateFRAccountIdentifier(FRAccountIdentifier accountIdentifier, String expectedIdentification,
+                                                    String expectedName, String expectedSchema, String expectedSecondaryId) {
+
+        assertEquals(expectedName, accountIdentifier.getName());
+        assertEquals(expectedIdentification, accountIdentifier.getIdentification());
+        assertEquals(expectedSchema, accountIdentifier.getSchemeName());
+        assertEquals(expectedSecondaryId, accountIdentifier.getSecondaryIdentification());
+    }
+
+}


### PR DESCRIPTION
This resolves an issue in the UI where the creditor name is not being displayed due to the creditorAccount object being missing.

https://github.com/SecureApiGateway/SecureApiGateway/issues/925