### PR TITLE
929: Use 2.8.9 of the gson library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 
     <properties>
         <uk.bom.version>0.9.1-SNAPSHOT</uk.bom.version>
+        <gson.version>2.8.9</gson.version>
     </properties>
 
     <dependencyManagement>
@@ -52,6 +53,11 @@
                 <version>${uk.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/secure-api-gateway-ob-uk-rcs-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-api/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
         </dependency>
 
         <!-- ForgeRock Test dependencies -->

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
         </dependency>
         <!-- External Test dependencies -->
         <dependency>

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>


### PR DESCRIPTION
Address a dependabot version issue

Issue: https://github.com/secureapigateway/secureapigateway/issues/929