### PR TITLE
Upgrade deployment service name and configmap ref

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: securebanking-openbanking-uk-rcs
+name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.9.1
+appVersion: 0.9.1

--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -57,12 +57,12 @@ spec:
           - name: CONSENT_REPO_URI
             valueFrom:
               configMapKeyRef:
-                name: securebanking-platform-config
+                name: deployment-config
                 key: CONSENT_REPO_URI
           - name: RS_API_URI
             valueFrom:
               configMapKeyRef:
-                name: securebanking-platform-config
+                name: deployment-config
                 key: RS_API_URI
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
@@ -75,12 +75,12 @@ spec:
           - name: RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID
             valueFrom:
               configMapKeyRef:
-                name: securebanking-platform-config
+                name: deployment-config
                 key: RCS_CONSENT_RESPONSE_JWT_SIGNINGKEYID
           - name: RCS_CONSENT_RESPONSE_JWT_ISSUER
             valueFrom:
               configMapKeyRef:
-                name: securebanking-platform-config
+                name: deployment-config
                 key: RCS_CONSENT_RESPONSE_JWT_ISSUER
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}


### PR DESCRIPTION
- Updated deployment descriptor configmapref to use 'deployment-config'
- Updated chart descriptor to update deployment name to 'remote-consent-service'

Issue: https://github.com/secureapigateway/secureapigateway/issues/851