### PR TITLE
947: added logic to store the accounId in the consent and skip patch the debtor account in the consent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.0</uk.bom.version>
+        <uk.bom.version>1.0.2</uk.bom.version>
         <gson.version>2.10.1</gson.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/models/ConsentClientDecisionRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/models/ConsentClientDecisionRequest.java
@@ -49,7 +49,7 @@ public class ConsentClientDecisionRequest {
     private JWTClaimsSet jwtClaimsSet;
 
     private List<String> accountIds;
-
+    private String accountId;
     private ConsentClientDecisionRequestData data;
     private String resourceOwnerUsername;
 }

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/test/support/ConsentDecisionRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/test/support/ConsentDecisionRequestTestDataFactory.java
@@ -31,6 +31,7 @@ import static java.util.UUID.randomUUID;
  */
 public class ConsentDecisionRequestTestDataFactory {
 
+    public static final String ACC_ID = "1c214525-d0c8-4d13-xxx-b812c6fafabe";
     // ACCOUNTS
     public static ConsentClientDecisionRequest aValidAccountConsentClientDecisionRequest() {
         return aValidAccountConsentClientDecisionRequestBuilder().build();
@@ -52,8 +53,18 @@ public class ConsentDecisionRequestTestDataFactory {
         return getAccountConsentClientDecisionRequestBuilder(intentId);
     }
 
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidPaymentConsentClientDecisionRequestBuilder(String intentId) {
+        return getPaymentConsentClientDecisionRequestBuilder(intentId);
+    }
+
+
+
     private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidAccountConsentClientDecisionRequestBuilder(String intentId, String clientId) {
         return getAccountConsentClientDecisionRequestBuilder(intentId, clientId);
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidPaymentConsentClientDecisionRequestBuilder(String intentId, String clientId) {
+        return getPaymentConsentClientDecisionRequestBuilder(intentId, clientId);
     }
 
     private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getAccountConsentClientDecisionRequestBuilder(IntentType intentType) {
@@ -88,6 +99,25 @@ public class ConsentDecisionRequestTestDataFactory {
                 .scopes(List.of("openid", "accounts"));
     }
 
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getPaymentConsentClientDecisionRequestBuilder(String intentId) {
+        return ConsentClientDecisionRequest.builder()
+                .intentId(intentId)
+                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                .data(ConsentClientDecisionRequestData.builder()
+                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
+                        .build())
+                .accountId(aValidFRAccountWithBalance().getId())
+                .clientId(randomUUID().toString())
+                .accountIds(List.of(aValidFRAccountWithBalance().toString()))
+                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
+                .resourceOwnerUsername(randomUUID().toString())
+                .scopes(List.of("openid", "accounts"));
+    }
+
+
+
     private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getAccountConsentClientDecisionRequestBuilder(String intentId, String clientId) {
         return ConsentClientDecisionRequest.builder()
                 .intentId(intentId)
@@ -104,64 +134,7 @@ public class ConsentDecisionRequestTestDataFactory {
                 .scopes(List.of("openid", "accounts"));
     }
 
-    // DOMESTIC PAYMENTS
-    public static ConsentClientDecisionRequest aValidDomesticPaymentConsentClientDecisionRequest() {
-        return aValidDomesticPaymentConsentDecisionBuilder().build();
-    }
-
-    public static ConsentClientDecisionRequest aValidDomesticPaymentConsentClientDecisionRequest(String intentId) {
-        return aValidAccountConsentClientDecisionRequestBuilder(intentId).build();
-    }
-
-    public static ConsentClientDecisionRequest aValidDomesticPaymentConsentClientDecisionRequest(String intentId, String clientId) {
-        return aValidAccountConsentClientDecisionRequestBuilder(intentId, clientId).build();
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidDomesticPaymentConsentDecisionBuilder() {
-        return getDomesticPaymentConsentDecisionBuilder(IntentType.PAYMENT_DOMESTIC_CONSENT);
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidDomesticPaymentConsentDecisionBuilder(String intentId) {
-        return getAccountConsentClientDecisionRequestBuilder(intentId);
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidDomesticPaymentConsentDecisionBuilder(String intentId, String clientId) {
-        return getAccountConsentClientDecisionRequestBuilder(intentId, clientId);
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getDomesticPaymentConsentDecisionBuilder(IntentType intentType) {
-        return ConsentClientDecisionRequest.builder()
-                .intentId(intentType.generateIntentId())
-                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
-                .data(ConsentClientDecisionRequestData.builder()
-                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
-                        .build())
-                .clientId(randomUUID().toString())
-                .accountIds(List.of(aValidFRAccountWithBalance().toString()))
-                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
-                .resourceOwnerUsername(randomUUID().toString())
-                .scopes(List.of("openid", "payments"));
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getDomesticPaymentConsentDecisionBuilder(String intentId) {
-        return ConsentClientDecisionRequest.builder()
-                .intentId(intentId)
-                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
-                .data(ConsentClientDecisionRequestData.builder()
-                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
-                        .build())
-                .clientId(randomUUID().toString())
-                .accountIds(List.of(aValidFRAccountWithBalance().toString()))
-                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
-                .resourceOwnerUsername(randomUUID().toString())
-                .scopes(List.of("openid", "payments"));
-    }
-
-    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getDomesticPaymentConsentDecisionBuilder(String intentId, String clientId) {
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getPaymentConsentClientDecisionRequestBuilder(String intentId, String clientId) {
         return ConsentClientDecisionRequest.builder()
                 .intentId(intentId)
                 .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
@@ -171,7 +144,81 @@ public class ConsentDecisionRequestTestDataFactory {
                         .status(Constants.ConsentDecisionStatus.AUTHORISED)
                         .build())
                 .clientId(clientId)
-                .accountIds(List.of(aValidFRAccountWithBalance().toString()))
+                .accountId(ACC_ID)
+                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
+                .resourceOwnerUsername(randomUUID().toString())
+                .scopes(List.of("openid", "accounts"));
+    }
+
+
+    // DOMESTIC PAYMENTS
+    public static ConsentClientDecisionRequest aValidPaymentConsentClientDecisionRequest() {
+        return aValidPaymentConsentDecisionBuilder().build();
+    }
+
+    public static ConsentClientDecisionRequest aValidPaymentConsentClientDecisionRequest(String intentId) {
+        return aValidPaymentConsentClientDecisionRequestBuilder(intentId).build();
+    }
+
+    public static ConsentClientDecisionRequest aValidPaymentConsentClientDecisionRequest(String intentId, String clientId) {
+        return aValidPaymentConsentClientDecisionRequestBuilder(intentId, clientId).build();
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidPaymentConsentDecisionBuilder() {
+        return getPaymentConsentDecisionBuilder(IntentType.PAYMENT_DOMESTIC_CONSENT);
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidPaymentConsentDecisionBuilder(String intentId) {
+        return getPaymentConsentClientDecisionRequestBuilder(intentId);
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder aValidPaymentConsentDecisionBuilder(String intentId, String clientId) {
+        return getPaymentConsentClientDecisionRequestBuilder(intentId, clientId);
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getPaymentConsentDecisionBuilder(IntentType intentType) {
+        return ConsentClientDecisionRequest.builder()
+                .intentId(intentType.generateIntentId())
+                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                .data(ConsentClientDecisionRequestData.builder()
+                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
+                        .build())
+                .clientId(randomUUID().toString())
+                .accountId(ACC_ID)
+                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
+                .resourceOwnerUsername(randomUUID().toString())
+                .scopes(List.of("openid", "payments"));
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getPaymentConsentDecisionBuilder(String intentId) {
+        return ConsentClientDecisionRequest.builder()
+                .intentId(intentId)
+                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                .data(ConsentClientDecisionRequestData.builder()
+                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
+                        .build())
+                .clientId(randomUUID().toString())
+                .accountId(ACC_ID)
+                .jwtClaimsSet(new JWTClaimsSet.Builder().build())
+                .resourceOwnerUsername(randomUUID().toString())
+                .scopes(List.of("openid", "payments"));
+    }
+
+    private static ConsentClientDecisionRequest.ConsentClientDecisionRequestBuilder getPaymentConsentDecisionBuilder(String intentId, String clientId) {
+        return ConsentClientDecisionRequest.builder()
+                .intentId(intentId)
+                .consentJwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+                        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                .data(ConsentClientDecisionRequestData.builder()
+                        .status(Constants.ConsentDecisionStatus.AUTHORISED)
+                        .build())
+                .clientId(clientId)
+                .accountId(ACC_ID)
                 .jwtClaimsSet(new JWTClaimsSet.Builder().build())
                 .resourceOwnerUsername(randomUUID().toString())
                 .scopes(List.of("openid", "payments"));


### PR DESCRIPTION
- Added accountId field in the request object to patch the consent, used in RS when the debtor account in the initiation object It's validated
    - The accountId will be the debtor account if has been provided in the consent, otherwise will be the account chosen by the user in the consent decision. 
- Test coverage improvements Issue: https://github.com/secureapigateway/secureapigateway/issues/947