### PR TITLE
969: Update helm chart to build the release 1.0.1

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1


### PR DESCRIPTION
- Helm Charts version updated to 1.0.1 
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/969