### PR TITLE
995: prepare release 1.0.2

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.0.2
+appVersion: 1.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.2</uk.bom.version>
+        <uk.bom.version>1.0.4</uk.bom.version>
         <gson.version>2.10.1</gson.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>


### PR DESCRIPTION
- Updated helm chart to 1.0.2
- Bumped commons version 1.0.4

Issue: https://github.com/secureapigateway/secureapigateway/issues/995