### PR TITLE
1010: Improving unit test coverage and testing based on consent store configuration

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreEnabledIntentTypesTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreEnabledIntentTypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreEnabledIntentTypesTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreEnabledIntentTypesTest.java
@@ -1,0 +1,43 @@
+package com.forgerock.sapi.gateway.rcs.consent.store.repo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+class ConsentStoreEnabledIntentTypesTest {
+
+    @Test
+    public void testStoreWithPaymentDomesticConsentEnabled() {
+        final EnumSet<IntentType> enabledIntentTypes = EnumSet.of(IntentType.PAYMENT_DOMESTIC_CONSENT);
+        final ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes = new ConsentStoreEnabledIntentTypes(enabledIntentTypes);
+        assertTrue(consentStoreEnabledIntentTypes.isIntentTypeSupported(IntentType.PAYMENT_DOMESTIC_CONSENT));
+
+        for (IntentType disabledIntentType : EnumSet.complementOf(enabledIntentTypes)) {
+            assertFalse(consentStoreEnabledIntentTypes.isIntentTypeSupported(disabledIntentType));
+        }
+    }
+
+    @Test
+    public void testStoreWithAllIntentTypesDisabled() {
+        final ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes = new ConsentStoreEnabledIntentTypes(EnumSet.noneOf(IntentType.class));
+        for (IntentType intentType : IntentType.values()) {
+            assertFalse(consentStoreEnabledIntentTypes.isIntentTypeSupported(intentType));
+        }
+    }
+
+    // NOTE: this test will need to be updated over time as the set of implemented types increases
+    @Test
+    public void testThatYouCannotEnableAnIntentTypeThatHasNotBeenImplemented() {
+        // Try to enable Accounts which are not yet implemented
+        final EnumSet<IntentType> intentsToEnable = EnumSet.of(IntentType.PAYMENT_DOMESTIC_CONSENT, IntentType.ACCOUNT_ACCESS_CONSENT);
+        final ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes = new ConsentStoreEnabledIntentTypes(intentsToEnable);
+
+        assertTrue(consentStoreEnabledIntentTypes.isIntentTypeSupported(IntentType.PAYMENT_DOMESTIC_CONSENT));
+        assertFalse(consentStoreEnabledIntentTypes.isIntentTypeSupported(IntentType.ACCOUNT_ACCESS_CONSENT)); // Not implemented so cannot be enabled
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/DefaultDomesticPaymentConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/DefaultDomesticPaymentConsentServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.DomesticPaymentConsentEntity;
@@ -45,7 +44,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-class DefaultDomesticPaymentConsentServiceTest extends BaseConsentServiceTest<DomesticPaymentConsentEntity, DomesticPaymentAuthoriseConsentArgs> {
+public class DefaultDomesticPaymentConsentServiceTest extends BaseConsentServiceTest<DomesticPaymentConsentEntity, DomesticPaymentAuthoriseConsentArgs> {
 
     @Autowired
     private DefaultDomesticPaymentConsentService service;
@@ -89,9 +88,15 @@ class DefaultDomesticPaymentConsentServiceTest extends BaseConsentServiceTest<Do
 
     @Override
     protected DomesticPaymentConsentEntity getValidConsentEntity() {
-        final OBWriteDomesticConsent4 obConsent = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
         final String apiClientId = "test-client-987";
+        return createValidConsentEntity(apiClientId);
+    }
 
+    public static DomesticPaymentConsentEntity createValidConsentEntity(String apiClientId) {
+        return createValidConsentEntity(OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4(), apiClientId);
+    }
+
+    public static DomesticPaymentConsentEntity createValidConsentEntity(OBWriteDomesticConsent4 obConsent, String apiClientId) {
         final DomesticPaymentConsentEntity domesticPaymentConsent = new DomesticPaymentConsentEntity();
         domesticPaymentConsent.setRequestType(obConsent.getClass().getSimpleName());
         domesticPaymentConsent.setRequestVersion(OBVersion.v3_1_10);
@@ -100,7 +105,7 @@ class DefaultDomesticPaymentConsentServiceTest extends BaseConsentServiceTest<Do
         domesticPaymentConsent.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
         domesticPaymentConsent.setIdempotencyKey(UUID.randomUUID().toString());
         domesticPaymentConsent.setIdempotencyKeyExpiration(DateTime.now().plusDays(1));
-        domesticPaymentConsent.setCharges(List.of(new OBWriteDomesticConsentResponse5DataCharges().amount(new OBActiveOrHistoricCurrencyAndAmount().currency("GBP").amount("11.23")).chargeBearer(OBChargeBearerType1Code.BORNEBYCREDITOR).type("fee")));
+        domesticPaymentConsent.setCharges(List.of(new OBWriteDomesticConsentResponse5DataCharges().amount(new OBActiveOrHistoricCurrencyAndAmount().currency("GBP").amount("0.25")).chargeBearer(OBChargeBearerType1Code.BORNEBYCREDITOR).type("fee")));
         return domesticPaymentConsent;
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -156,6 +156,13 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.forgerock.sapi.gateway</groupId>
+            <artifactId>secure-api-gateway-ob-uk-rcs-consent-store-repo</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- External Test dependencies -->
         <dependency>
@@ -176,6 +183,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionService.java
@@ -45,16 +45,16 @@ public class ConsentStoreDecisionService {
         }
     }
 
-    public void authoriseConsent(IntentType intentType, String intentId, String clientId, String resourceOwnerId, String authorisedAccountId) {
+    public void authoriseConsent(IntentType intentType, String intentId, String apiClientId, String resourceOwnerId, String authorisedAccountId) {
         checkIntentTypeIsSupported(intentType);
         // TODO dispatch to correct service when we have more impls
-        final DomesticPaymentAuthoriseConsentArgs authoriseConsentArgs = new DomesticPaymentAuthoriseConsentArgs(intentId, clientId, resourceOwnerId, authorisedAccountId);
+        final DomesticPaymentAuthoriseConsentArgs authoriseConsentArgs = new DomesticPaymentAuthoriseConsentArgs(intentId, apiClientId, resourceOwnerId, authorisedAccountId);
         domesticPaymentConsentService.authoriseConsent(authoriseConsentArgs);
     }
 
-    public void rejectConsent(IntentType intentType, String intentId, String clientId, String resourceOwnerId) {
+    public void rejectConsent(IntentType intentType, String intentId, String apiClientId, String resourceOwnerId) {
         checkIntentTypeIsSupported(intentType);
         // TODO dispatch to correct service when we have more impls
-        domesticPaymentConsentService.rejectConsent(intentId, clientId, resourceOwnerId);
+        domesticPaymentConsentService.rejectConsent(intentId, apiClientId, resourceOwnerId);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -79,7 +79,7 @@ consent:
   store:
     enabled:
       # Controls which intentTypes will use the new Consent Store (format: comma separated list)
-      intentTypes:
+      intentTypes: PAYMENT_DOMESTIC_CONSENT
 
 spring:
   data:

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -79,7 +79,7 @@ consent:
   store:
     enabled:
       # Controls which intentTypes will use the new Consent Store (format: comma separated list)
-      intentTypes: PAYMENT_DOMESTIC_CONSENT
+      intentTypes:
 
 spring:
   data:

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentDetailsApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentDetailsApiControllerRcsConsentStoreTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api;
+
+import static com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.test.support.ConsentDetailsRequestTestDataFactory.aValidConsentDetailsRequest;
+import static com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.test.support.UserTestDataFactory.aValidUser;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.PaymentsConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.User;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.UserServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.RCSServerApplicationTestSupport;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.testsupport.JwtTestHelper;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreEnabledIntentTypes;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+/**
+ * Tests for the {@link ConsentDetailsApiController} when it is configured to use the RCS Consent Store module.
+ */
+@ActiveProfiles("test")
+@SpringBootTest(classes = RCSServerApplicationTestSupport.class, webEnvironment = RANDOM_PORT)
+public class ConsentDetailsApiControllerRcsConsentStoreTest {
+
+    @LocalServerPort
+    private int port;
+
+    private String consentDetailsUri;
+
+    @BeforeEach
+    public void beforeEach() {
+        consentDetailsUri =  "http://localhost:" + port + "/rcs/api/consent/details";
+    }
+
+    @MockBean
+    private UserServiceClient userServiceClient;
+
+    @MockBean
+    private ConsentStoreDetailsService consentStoreDetailsService;
+
+    @Autowired
+    private ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private static DomesticPaymentConsentDetails createDomesticPaymentConsentDetails() {
+        final DomesticPaymentConsentDetails domesticPaymentConsentDetails = new DomesticPaymentConsentDetails();
+        domesticPaymentConsentDetails.setConsentId(IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId());
+        domesticPaymentConsentDetails.setLogo("tppLogo");
+        return domesticPaymentConsentDetails;
+    }
+
+    private static Stream<Arguments> validPaymentConsentDetailsArguments() {
+        return Stream.of(
+                arguments(IntentType.PAYMENT_DOMESTIC_CONSENT, createDomesticPaymentConsentDetails(), DomesticPaymentConsentDetails.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validPaymentConsentDetailsArguments")
+    public <C extends PaymentsConsentDetails> void shouldGetDomesticPaymentConsentDetails(IntentType intentType, ConsentDetails testConsentDetails,
+                                                       Class<C> consentDetailsClass) throws Exception {
+
+        Assumptions.assumeTrue(consentStoreEnabledIntentTypes.isIntentTypeSupported(intentType));
+
+        final String consentId = testConsentDetails.getConsentId();
+        ConsentClientDetailsRequest consentDetailsRequest = aValidConsentDetailsRequest(consentId);
+        User user = aValidUser();
+        consentDetailsRequest.setUser(user);
+        given(userServiceClient.getUser(anyString())).willReturn(user);
+        given(consentStoreDetailsService.isIntentTypeSupported(eq(intentType))).willReturn(Boolean.TRUE);
+
+        final ArgumentCaptor<ConsentClientDetailsRequest> consentDetailsArgCaptor = ArgumentCaptor.forClass(ConsentClientDetailsRequest.class);
+        given(consentStoreDetailsService.getDetailsFromConsentStore(eq(intentType), consentDetailsArgCaptor.capture())).willReturn(testConsentDetails);
+
+        String jwtRequest = JwtTestHelper.consentRequestJwt(
+                consentDetailsRequest.getClientId(),
+                consentDetailsRequest.getIntentId(),
+                consentDetailsRequest.getUser().getId()
+        );
+        HttpEntity<String> request = new HttpEntity<>(jwtRequest, headers());
+
+        // when
+        ResponseEntity<C> response = restTemplate.postForEntity(consentDetailsUri, request, consentDetailsClass);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        final ConsentClientDetailsRequest capturedConsentClientDetailsRequest = consentDetailsArgCaptor.getValue();
+        assertThat(capturedConsentClientDetailsRequest.getClientId()).isEqualTo(consentDetailsRequest.getClientId());
+        assertThat(capturedConsentClientDetailsRequest.getUser()).isEqualTo(user);
+        assertThat(capturedConsentClientDetailsRequest.getIntentId()).isEqualTo(consentDetailsRequest.getIntentId());
+        assertThat(capturedConsentClientDetailsRequest.getConsentRequestJwt()).isNotNull();
+
+        final C consentDetailsResponse = response.getBody();
+        assertThat(consentDetailsResponse).isEqualTo(testConsentDetails);
+    }
+
+    private HttpHeaders headers() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(APPLICATION_JSON));
+        headers.setContentType(APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionServiceTest.java
@@ -1,0 +1,73 @@
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreEnabledIntentTypes;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.DomesticPaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.DomesticPaymentConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@ExtendWith(MockitoExtension.class)
+class ConsentStoreDecisionServiceTest {
+
+    private static final String TEST_API_CLIENT_ID = "api-client-1";
+    private static final String TEST_RESOURCE_OWNER_ID = "user-123456";
+    private static final String TEST_AUTHORISED_ACC_ID = "authorised-acc-1";
+    @Mock
+    private ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes;
+
+    @Mock
+    private DomesticPaymentConsentService domesticPaymentConsentService;
+
+    @InjectMocks
+    private ConsentStoreDecisionService consentStoreDecisionService;
+
+    @Test
+    public void testUnableToSubmitDecisionForConsentTypeNotEnabled() {
+        final IntentType intentType = IntentType.PAYMENT_DOMESTIC_CONSENT;
+
+        assertEquals("PAYMENT_DOMESTIC_CONSENT not supported", assertThrows(IllegalStateException.class,
+                () -> consentStoreDecisionService.authoriseConsent(intentType, intentType.generateIntentId(), TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, TEST_AUTHORISED_ACC_ID)).getMessage());
+        assertEquals("PAYMENT_DOMESTIC_CONSENT not supported", assertThrows(IllegalStateException.class,
+                () -> consentStoreDecisionService.rejectConsent(intentType, intentType.generateIntentId(), TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID)).getMessage());
+    }
+
+    @Test
+    public void testSubmitDomesticPaymentAuthoriseDecision() {
+        final IntentType paymentDomesticConsent = IntentType.PAYMENT_DOMESTIC_CONSENT;
+        given(consentStoreEnabledIntentTypes.isIntentTypeSupported(eq(paymentDomesticConsent))).willReturn(Boolean.TRUE);
+
+        final String intentId = paymentDomesticConsent.generateIntentId();
+
+        consentStoreDecisionService.authoriseConsent(paymentDomesticConsent, intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, TEST_AUTHORISED_ACC_ID);
+
+        verify(domesticPaymentConsentService).authoriseConsent(refEq(new DomesticPaymentAuthoriseConsentArgs(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, TEST_AUTHORISED_ACC_ID)));
+        verifyNoMoreInteractions(domesticPaymentConsentService);
+    }
+
+    @Test
+    public void testSubmitDomesticPaymentRejectDecision() {
+        final IntentType paymentDomesticConsent = IntentType.PAYMENT_DOMESTIC_CONSENT;
+        given(consentStoreEnabledIntentTypes.isIntentTypeSupported(eq(paymentDomesticConsent))).willReturn(Boolean.TRUE);
+
+        final String intentId = paymentDomesticConsent.generateIntentId();
+
+        consentStoreDecisionService.rejectConsent(paymentDomesticConsent, intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID);
+
+        verify(domesticPaymentConsentService).rejectConsent(eq(intentId), eq(TEST_API_CLIENT_ID), eq(TEST_RESOURCE_OWNER_ID));
+        verifyNoMoreInteractions(domesticPaymentConsentService);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDecisionServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,5 +84,4 @@ class ConsentStoreDecisionServiceTest {
         verify(domesticPaymentConsentService).rejectConsent(eq(intentId), eq(TEST_API_CLIENT_ID), eq(TEST_RESOURCE_OWNER_ID));
         verifyNoMoreInteractions(domesticPaymentConsentService);
     }
-
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDetailsServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api;
+
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.DefaultDomesticPaymentConsentServiceTest.createValidConsentEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.account.FRAccountWithBalanceTestDataFactory;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ApiClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.User;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.AccountService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreEnabledIntentTypes;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.DomesticPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.DomesticPaymentConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@ExtendWith(MockitoExtension.class)
+class ConsentStoreDetailsServiceTest {
+
+    private static final String TEST_API_PROVIDER = "Test Api Provider";
+    @Mock
+    private ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes;
+
+    @Mock
+    private DomesticPaymentConsentService domesticPaymentConsentService;
+
+    @Mock
+    private AccountService accountService;
+
+    @Mock
+    private ApiClientServiceClient apiClientServiceClient;
+
+    @Mock
+    private ApiProviderConfiguration apiProviderConfiguration;
+
+    @Mock
+    private DebtorAccountService debtorAccountService;
+
+    @InjectMocks
+    private ConsentStoreDetailsService consentStoreDetailsService;
+    private final User testUser;
+
+    private final List<FRAccountWithBalance> testUserBankAccounts;
+
+    private final ApiClient testApiClient;
+
+
+    public ConsentStoreDetailsServiceTest() {
+        testUser = new User();
+        testUser.setId("test-user-1");
+        testUser.setUserName("testUser");
+
+        testApiClient = new ApiClient();
+        testApiClient.setId("acme-tpp-1");
+        testApiClient.setName("ACME Corp");
+
+        testUserBankAccounts = List.of(FRAccountWithBalanceTestDataFactory.aValidFRAccountWithBalance());
+    }
+
+    @Test
+    void testIsIntentTypeSupportedAllIntentTypesDisabled() {
+        for (IntentType intentType : IntentType.values()) {
+            assertFalse(consentStoreDetailsService.isIntentTypeSupported(intentType));
+        }
+    }
+
+    @Test
+    void testGetDetailsFailsIfIntentTypeDisabled() {
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+                consentStoreDetailsService.getDetailsFromConsentStore(IntentType.ACCOUNT_ACCESS_CONSENT,
+                        new ConsentClientDetailsRequest(null, null, null, null)));
+
+        assertEquals("ACCOUNT_ACCESS_CONSENT support not currently implemented in Consent Store module", ex.getMessage());
+    }
+
+    @Test
+    void testGetDomesticPaymentDetails() throws ExceptionClient {
+        given(apiClientServiceClient.getApiClient(eq(testApiClient.getId()))).willReturn(testApiClient);
+        given(accountService.getAccountsWithBalance(testUser.getId())).willReturn(testUserBankAccounts);
+        given(apiProviderConfiguration.getName()).willReturn(TEST_API_PROVIDER);
+        given(consentStoreEnabledIntentTypes.isIntentTypeSupported(eq(IntentType.PAYMENT_DOMESTIC_CONSENT))).willReturn(Boolean.TRUE);
+
+        final String intentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+
+        final DomesticPaymentConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+        consentEntity.setId(intentId);
+        given(domesticPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+
+        final ConsentDetails consentDetails = consentStoreDetailsService.getDetailsFromConsentStore(IntentType.PAYMENT_DOMESTIC_CONSENT,
+                new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(DomesticPaymentConsentDetails.class);
+        DomesticPaymentConsentDetails domesticPaymentConsentDetails = (DomesticPaymentConsentDetails) consentDetails;
+        assertThat(domesticPaymentConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(domesticPaymentConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+        assertThat(domesticPaymentConsentDetails.getPaymentReference()).isEqualTo("FRESCO-037");
+        assertThat(domesticPaymentConsentDetails.getCharges()).isEqualTo(new FRAmount("0.25", "GBP"));
+        assertThat(domesticPaymentConsentDetails.getInstructedAmount()).isEqualTo(new FRAmount("10.01", "GBP"));
+        assertThat(domesticPaymentConsentDetails.getInitiation()).isEqualTo(FRWriteDomesticConsentConverter.toFRWriteDomesticDataInitiation(consentEntity.getRequestObj().getData().getInitiation()));
+        assertThat(domesticPaymentConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(domesticPaymentConsentDetails.getAccounts()).isEqualTo(testUserBankAccounts);
+        assertThat(domesticPaymentConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(domesticPaymentConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(domesticPaymentConsentDetails.getUserId()).isEqualTo(testUser.getId());
+
+        assertThat(domesticPaymentConsentDetails.getDebtorAccount()).isNull();
+
+        verifyNoInteractions(debtorAccountService);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/ConsentStoreDetailsServiceTest.java
@@ -25,9 +25,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -49,6 +54,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreEnabledInte
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.DomesticPaymentConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.DomesticPaymentConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5DataCharges;
 
 @ExtendWith(MockitoExtension.class)
 class ConsentStoreDetailsServiceTest {
@@ -142,5 +150,37 @@ class ConsentStoreDetailsServiceTest {
         assertThat(domesticPaymentConsentDetails.getDebtorAccount()).isNull();
 
         verifyNoInteractions(debtorAccountService);
+    }
+
+
+    private static Stream<Arguments> chargeParameters() {
+        return Stream.of(
+                Arguments.of(List.of("0.01", "0.02", "0.2"), "0.23"),
+                Arguments.of(List.of("0"), "0"),
+                Arguments.of(List.of("0.25"), "0.25")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("chargeParameters")
+    void testCalculateCharges(List<String> chargeAmounts, String expectedTotal) {
+        final List<OBWriteDomesticConsentResponse5DataCharges> charges = chargeAmounts.stream().map(charge -> {
+            final OBWriteDomesticConsentResponse5DataCharges obCharge = new OBWriteDomesticConsentResponse5DataCharges();
+            obCharge.setAmount(new OBActiveOrHistoricCurrencyAndAmount().amount(charge).currency("GBP"));
+            return obCharge;
+        }).collect(Collectors.toList());
+
+        assertThat(ConsentStoreDetailsService.computeTotalChargeAmount(charges)).isEqualTo(new FRAmount(expectedTotal, "GBP"));
+    }
+
+    @Test
+    void testCalculateChargesMismatchCcy() {
+        final List<OBWriteDomesticConsentResponse5DataCharges> charges = List.of(
+                new OBWriteDomesticConsentResponse5DataCharges().amount(new OBActiveOrHistoricCurrencyAndAmount().amount("0.01").currency("GBP")),
+                new OBWriteDomesticConsentResponse5DataCharges().amount(new OBActiveOrHistoricCurrencyAndAmount().amount("0.2").currency("EUR"))
+        );
+
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> ConsentStoreDetailsService.computeTotalChargeAmount(charges));
+        assertThat(ex.getMessage()).isEqualTo("Charges contain more than 1 currency, all charges must be in the same currency");
     }
 }


### PR DESCRIPTION
Adding JUnit assumptions to existing Details and Decision controller tests to only run if the particular IntentType is using the old IDM store.

Adding new test classes to test the same controllers when configured to use the RCS Consent Store.

Also improving coverage missed in previous PR.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1010