### PR TITLE
993: Configuring Spring Data MongoDB properties

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -55,6 +55,21 @@ spec:
           env:
           - name: SPRING_DATA_MONGODB_HOST
             value: {{ .Values.deployment.mongodb.host }}
+          - name: SPRING_DATA_MONGODB_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_USERNAME
+          - name: SPRING_DATA_MONGODB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_USERNAME
+          - name: SPRING_DATA_MONGODB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_PASSWORD
           - name: CONSENT_REPO_URI
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Configuring the properties via environment variables supplied from a secret. The properties configure the database, username and password to use in the MongoDB connection string.

Note: we have a convention of using the same database name and username, hence both env vars using the same key.

https://github.com/SecureApiGateway/SecureApiGateway/issues/993