### PR TITLE
1023: Changing Consent Entity definition to store the FR data model representation of a Consent Request

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
@@ -61,7 +61,6 @@ public class AccountAccessConsentApiController implements AccountAccessConsentAp
         consentEntity.setRequestObj(request.getConsentRequest());
         consentEntity.setApiClientId(apiClientId);
         consentEntity.setRequestVersion(obVersion);
-        consentEntity.setRequestType(request.getConsentRequest().getClass().getSimpleName());
         consentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
 
         final AccountAccessConsentEntity persistedEntity = consentService.createConsent(consentEntity);
@@ -99,7 +98,6 @@ public class AccountAccessConsentApiController implements AccountAccessConsentAp
         dto.setStatus(entity.getStatus());
         dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
         dto.setRequestVersion(entity.getRequestVersion());
-        dto.setRequestType(entity.getRequestType());
         dto.setRequestObj(entity.getRequestObj());
         dto.setResourceOwnerId(entity.getResourceOwnerId());
         return dto;

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
@@ -73,7 +73,6 @@ public class DomesticPaymentConsentApiController implements DomesticPaymentConse
     public ResponseEntity<DomesticPaymentConsent> createConsent(CreateDomesticPaymentConsentRequest request, String apiClientId) {
         logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
         final DomesticPaymentConsentEntity domesticPaymentConsent = new DomesticPaymentConsentEntity();
-        domesticPaymentConsent.setRequestType(request.getConsentRequest().getClass().getSimpleName());
         domesticPaymentConsent.setRequestVersion(obVersion);
         domesticPaymentConsent.setApiClientId(request.getApiClientId());
         domesticPaymentConsent.setRequestObj(request.getConsentRequest());
@@ -118,7 +117,6 @@ public class DomesticPaymentConsentApiController implements DomesticPaymentConse
         dto.setId(entity.getId());
         dto.setStatus(entity.getStatus());
         dto.setRequestObj(entity.getRequestObj());
-        dto.setRequestType(entity.getRequestType());
         dto.setRequestVersion(entity.getRequestVersion());
         dto.setApiClientId(entity.getApiClientId());
         dto.setResourceOwnerId(entity.getResourceOwnerId());

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentValidationHelpers.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentValidationHelpers.java
@@ -41,7 +41,6 @@ public class AccountAccessConsentValidationHelpers {
         assertThat(consent.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION.toString());
         assertThat(consent.getApiClientId()).isEqualTo(createAccountAccessConsentRequest.getApiClientId());
         assertThat(consent.getRequestObj()).isEqualTo(createAccountAccessConsentRequest.getConsentRequest());
-        assertThat(consent.getRequestType()).isEqualTo("OBReadConsent1");
         assertThat(consent.getRequestVersion()).isEqualTo(OBVersion.v3_1_10);
         assertThat(consent.getResourceOwnerId()).isNull();
         assertThat(consent.getAuthorisedAccountIds()).isNull();
@@ -74,7 +73,6 @@ public class AccountAccessConsentValidationHelpers {
         assertThat(updatedConsent.getApiClientId()).isEqualTo(consent.getApiClientId());
         assertThat(updatedConsent.getRequestObj()).isEqualTo(consent.getRequestObj());
         assertThat(updatedConsent.getRequestVersion()).isEqualTo(consent.getRequestVersion());
-        assertThat(updatedConsent.getRequestType()).isEqualTo(consent.getRequestType());
         assertThat(updatedConsent.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
         assertThat(updatedConsent.getStatusUpdateDateTime()).isLessThan(DateTime.now()).isGreaterThan(consent.getStatusUpdateDateTime());
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConsentConverter;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domestic.v3_1_10.AuthoriseDomesticPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domestic.v3_1_10.ConsumeDomesticPaymentConsentRequest;
@@ -60,7 +61,7 @@ public class DomesticPaymentConsentApiControllerTest extends BaseControllerTest<
     private static CreateDomesticPaymentConsentRequest buildCreateDomesticPaymentConsentRequest(String apiClientId, String idempotencyKey) {
         final CreateDomesticPaymentConsentRequest createDomesticPaymentConsentRequest = new CreateDomesticPaymentConsentRequest();
         final OBWriteDomesticConsent4 paymentConsent = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
-        createDomesticPaymentConsentRequest.setConsentRequest(paymentConsent);
+        createDomesticPaymentConsentRequest.setConsentRequest(FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(paymentConsent));
         createDomesticPaymentConsentRequest.setApiClientId(apiClientId);
         createDomesticPaymentConsentRequest.setIdempotencyKey(idempotencyKey);
         return createDomesticPaymentConsentRequest;
@@ -108,12 +109,12 @@ public class DomesticPaymentConsentApiControllerTest extends BaseControllerTest<
     public void testSameIdempotentKeyCanBeUsedByDifferentClients() {
         final String idempotencyKey = UUID.randomUUID().toString();
         final CreateDomesticPaymentConsentRequest client1CreateRequest = new CreateDomesticPaymentConsentRequest();
-        client1CreateRequest.setConsentRequest(OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4());
+        client1CreateRequest.setConsentRequest(FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()));
         client1CreateRequest.setApiClientId("client-1");
         client1CreateRequest.setIdempotencyKey(idempotencyKey);
 
         final CreateDomesticPaymentConsentRequest client2CreateRequest = new CreateDomesticPaymentConsentRequest();
-        client2CreateRequest.setConsentRequest(OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4());
+        client2CreateRequest.setConsentRequest(FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()));
         client2CreateRequest.setApiClientId("client-2");
         client2CreateRequest.setIdempotencyKey(idempotencyKey);
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentValidationHelpers.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentValidationHelpers.java
@@ -41,7 +41,6 @@ public class DomesticPaymentConsentValidationHelpers {
         assertThat(consent.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION.toString());
         assertThat(consent.getApiClientId()).isEqualTo(createDomesticPaymentConsentRequest.getApiClientId());
         assertThat(consent.getRequestObj()).isEqualTo(createDomesticPaymentConsentRequest.getConsentRequest());
-        assertThat(consent.getRequestType()).isEqualTo("OBWriteDomesticConsent4");
         assertThat(consent.getRequestVersion()).isEqualTo(OBVersion.v3_1_10);
         assertThat(consent.getCharges()).isEqualTo(createDomesticPaymentConsentRequest.getCharges());
         assertThat(consent.getIdempotencyKey()).isEqualTo(createDomesticPaymentConsentRequest.getIdempotencyKey());
@@ -78,7 +77,6 @@ public class DomesticPaymentConsentValidationHelpers {
         assertThat(updatedConsent.getApiClientId()).isEqualTo(consent.getApiClientId());
         assertThat(updatedConsent.getRequestObj()).isEqualTo(consent.getRequestObj());
         assertThat(updatedConsent.getRequestVersion()).isEqualTo(consent.getRequestVersion());
-        assertThat(updatedConsent.getRequestType()).isEqualTo(consent.getRequestType());
         assertThat(updatedConsent.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
         assertThat(updatedConsent.getStatusUpdateDateTime()).isLessThan(DateTime.now()).isGreaterThan(consent.getStatusUpdateDateTime());
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseConsent.java
@@ -37,8 +37,6 @@ public abstract class BaseConsent<T> {
     @Valid
     private T requestObj;
     @NotNull
-    private String requestType;
-    @NotNull
     private OBVersion requestVersion;
     @NotNull
     private String status;
@@ -65,14 +63,6 @@ public abstract class BaseConsent<T> {
 
     public void setRequestObj(T requestObj) {
         this.requestObj = requestObj;
-    }
-
-    public String getRequestType() {
-        return requestType;
-    }
-
-    public void setRequestType(String requestType) {
-        this.requestType = requestType;
     }
 
     public OBVersion getRequestVersion() {
@@ -128,7 +118,6 @@ public abstract class BaseConsent<T> {
         return "BaseConsent{" +
                 "id='" + id + '\'' +
                 ", requestObj=" + requestObj +
-                ", requestType='" + requestType + '\'' +
                 ", requestVersion=" + requestVersion +
                 ", status='" + status + '\'' +
                 ", apiClientId='" + apiClientId + '\'' +

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/domestic/v3_1_10/CreateDomesticPaymentConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/domestic/v3_1_10/CreateDomesticPaymentConsentRequest.java
@@ -22,19 +22,18 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.validation.annotation.Validated;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.BaseCreateConsentRequest;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5DataCharges;
-
 @Validated
-public class CreateDomesticPaymentConsentRequest extends BaseCreateConsentRequest<OBWriteDomesticConsent4> {
+public class CreateDomesticPaymentConsentRequest extends BaseCreateConsentRequest<FRWriteDomesticConsent> {
 
     @NotNull
     private String idempotencyKey;
 
     @Valid
-    private List<OBWriteDomesticConsentResponse5DataCharges> charges;
+    private List<FRCharge> charges;
 
     public String getIdempotencyKey() {
         return idempotencyKey;
@@ -44,11 +43,11 @@ public class CreateDomesticPaymentConsentRequest extends BaseCreateConsentReques
         this.idempotencyKey = idempotencyKey;
     }
 
-    public List<OBWriteDomesticConsentResponse5DataCharges> getCharges() {
+    public List<FRCharge> getCharges() {
         return charges;
     }
 
-    public void setCharges(List<OBWriteDomesticConsentResponse5DataCharges> charges) {
+    public void setCharges(List<FRCharge> charges) {
         this.charges = charges;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/domestic/v3_1_10/DomesticPaymentConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/domestic/v3_1_10/DomesticPaymentConsent.java
@@ -23,16 +23,15 @@ import javax.validation.constraints.NotNull;
 import org.joda.time.DateTime;
 import org.springframework.validation.annotation.Validated;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.BaseConsent;
-
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5DataCharges;
 
 /**
  * OBIE Domestic Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/domestic-payment-consents.html
  */
 @Validated
-public class DomesticPaymentConsent extends BaseConsent<OBWriteDomesticConsent4> {
+public class DomesticPaymentConsent extends BaseConsent<FRWriteDomesticConsent> {
 
     @NotNull
     private String idempotencyKey;
@@ -43,7 +42,7 @@ public class DomesticPaymentConsent extends BaseConsent<OBWriteDomesticConsent4>
     private String authorisedDebtorAccountId;
 
     @Valid
-    private List<OBWriteDomesticConsentResponse5DataCharges> charges;
+    private List<FRCharge> charges;
 
     public String getIdempotencyKey() {
         return idempotencyKey;
@@ -69,11 +68,11 @@ public class DomesticPaymentConsent extends BaseConsent<OBWriteDomesticConsent4>
         this.authorisedDebtorAccountId = authorisedDebtorAccountId;
     }
 
-    public List<OBWriteDomesticConsentResponse5DataCharges> getCharges() {
+    public List<FRCharge> getCharges() {
         return charges;
     }
 
-    public void setCharges(List<OBWriteDomesticConsentResponse5DataCharges> charges) {
+    public void setCharges(List<FRCharge> charges) {
         this.charges = charges;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/BaseConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/BaseConsentEntity.java
@@ -48,12 +48,6 @@ public class BaseConsentEntity<T> {
     private T requestObj;
 
     /**
-     * OBIE type name of the requestObj e.g. OBWriteDomesticConsent4
-     */
-    @NotNull
-    private String requestType;
-
-    /**
      * Version of OBIE API used to create this consent
      */
     @NotNull
@@ -101,9 +95,6 @@ public class BaseConsentEntity<T> {
         return requestObj;
     }
 
-    public String getRequestType() {
-        return requestType;
-    }
 
     public OBVersion getRequestVersion() {
         return requestVersion;
@@ -121,9 +112,6 @@ public class BaseConsentEntity<T> {
         this.requestObj = requestObj;
     }
 
-    public void setRequestType(String requestType) {
-        this.requestType = requestType;
-    }
 
     public void setRequestVersion(OBVersion requestVersion) {
         this.requestVersion = requestVersion;
@@ -167,7 +155,6 @@ public class BaseConsentEntity<T> {
                 "id='" + id + '\'' +
                 ", entityVersion=" + entityVersion +
                 ", requestObj=" + requestObj +
-                ", requestType='" + requestType + '\'' +
                 ", requestVersion=" + requestVersion +
                 ", status='" + status + '\'' +
                 ", apiClientId='" + apiClientId + '\'' +

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/DomesticPaymentConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/DomesticPaymentConsentEntity.java
@@ -24,17 +24,16 @@ import org.joda.time.DateTime;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.validation.annotation.Validated;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.BaseConsentEntity;
-
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5DataCharges;
 
 /**
  * OBIE Domestic Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/domestic-payment-consents.html
  */
 @Document("DomesticPaymentConsent")
 @Validated
-public class DomesticPaymentConsentEntity extends BaseConsentEntity<OBWriteDomesticConsent4> {
+public class DomesticPaymentConsentEntity extends BaseConsentEntity<FRWriteDomesticConsent> {
 
     /**
      * Key supplied by the ApiClient when creating the Consent, to enable the request to be made idempotent
@@ -60,7 +59,7 @@ public class DomesticPaymentConsentEntity extends BaseConsentEntity<OBWriteDomes
      * Optional - charges applied to the payment transaction
      */
     @Valid
-    private List<OBWriteDomesticConsentResponse5DataCharges> charges;
+    private List<FRCharge> charges;
 
     public void setAuthorisedDebtorAccountId(String authorisedDebtorAccountId) {
         this.authorisedDebtorAccountId = authorisedDebtorAccountId;
@@ -86,11 +85,11 @@ public class DomesticPaymentConsentEntity extends BaseConsentEntity<OBWriteDomes
         this.idempotencyKeyExpiration = idempotencyKeyExpiration;
     }
 
-    public List<OBWriteDomesticConsentResponse5DataCharges> getCharges() {
+    public List<FRCharge> getCharges() {
         return charges;
     }
 
-    public void setCharges(List<OBWriteDomesticConsentResponse5DataCharges> charges) {
+    public void setCharges(List<FRCharge> charges) {
         this.charges = charges;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/DomesticPaymentConsentRepositoryTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/DomesticPaymentConsentRepositoryTest.java
@@ -44,7 +44,6 @@ class DomesticPaymentConsentRepositoryTest {
         final DomesticPaymentConsentEntity entity = new DomesticPaymentConsentEntity();
         entity.setIdempotencyKey(key1);
         entity.setIdempotencyKeyExpiration(DateTime.now().plusDays(1));
-        entity.setRequestType("test");
         entity.setApiClientId(apiClientId);
         final DomesticPaymentConsentEntity savedEntity = repo.save(entity);
 
@@ -60,7 +59,6 @@ class DomesticPaymentConsentRepositoryTest {
         final DomesticPaymentConsentEntity entity = new DomesticPaymentConsentEntity();
         entity.setIdempotencyKey(key);
         entity.setIdempotencyKeyExpiration(DateTime.now().plusDays(1));
-        entity.setRequestType("test");
         entity.setApiClientId(client1);
 
         repo.save(entity);
@@ -83,7 +81,6 @@ class DomesticPaymentConsentRepositoryTest {
             final DomesticPaymentConsentEntity entity = new DomesticPaymentConsentEntity();
             entity.setIdempotencyKey(key);
             entity.setIdempotencyKeyExpiration(expiredTime);
-            entity.setRequestType("test");
             entity.setApiClientId(apiClient);
 
             repo.save(entity);

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/BaseConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/BaseConsentServiceTest.java
@@ -70,7 +70,6 @@ public abstract class BaseConsentServiceTest<T extends BaseConsentEntity<?>, A e
 
         assertThat(persistedConsent.getStatus()).isEqualTo(getNewConsentStatus());
 
-        assertThat(persistedConsent.getRequestType()).isEqualTo(consentObj.getRequestType());
         assertThat(persistedConsent.getRequestVersion()).isEqualTo(consentObj.getRequestVersion());
         assertThat(persistedConsent.getApiClientId()).isEqualTo(consentObj.getApiClientId());
 
@@ -126,7 +125,6 @@ public abstract class BaseConsentServiceTest<T extends BaseConsentEntity<?>, A e
         assertThat(authorisedConsent.getCreationDateTime()).isEqualTo(persistedConsent.getCreationDateTime());
         assertThat(authorisedConsent.getApiClientId()).isEqualTo(persistedConsent.getApiClientId());
         assertThat(authorisedConsent.getId()).isEqualTo(persistedConsent.getId());
-        assertThat(authorisedConsent.getRequestType()).isEqualTo(persistedConsent.getRequestType());
         assertThat(authorisedConsent.getRequestVersion()).isEqualTo(persistedConsent.getRequestVersion());
         assertThat(authorisedConsent.getRequestObj()).isEqualTo(persistedConsent.getRequestObj());
         validateConsentSpecificFields(persistedConsent, authorisedConsent);

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentServiceTest.java
@@ -65,7 +65,6 @@ public class DefaultAccountAccessConsentServiceTest extends BaseConsentServiceTe
         final AccountAccessConsentEntity accountAccessConsentEntity = new AccountAccessConsentEntity();
         accountAccessConsentEntity.setApiClientId(apiClientId);
         accountAccessConsentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
-        accountAccessConsentEntity.setRequestType(OBReadConsent1.class.getSimpleName());
         accountAccessConsentEntity.setRequestVersion(OBVersion.v3_1_10);
 
         final OBReadConsent1 obReadConsent = new OBReadConsent1();

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/DomesticPaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/DomesticPaymentConsentDetailsService.java
@@ -24,7 +24,8 @@ import org.springframework.stereotype.Component;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsentData;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticDataInitiation;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
@@ -38,10 +39,6 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreE
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 import com.google.common.annotations.VisibleForTesting;
-
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5DataCharges;
 
 @Component
 public class DomesticPaymentConsentDetailsService extends BaseConsentDetailsService<DomesticPaymentConsentEntity, DomesticPaymentConsentDetails> {
@@ -63,8 +60,8 @@ public class DomesticPaymentConsentDetailsService extends BaseConsentDetailsServ
         final FRAmount totalChargeAmount = computeTotalChargeAmount(consent.getCharges());
         consentDetails.setCharges(totalChargeAmount);
 
-        final OBWriteDomesticConsent4Data obConsentRequestData = consent.getRequestObj().getData();
-        final FRWriteDomesticDataInitiation initiation = FRWriteDomesticConsentConverter.toFRWriteDomesticDataInitiation(obConsentRequestData.getInitiation());
+        final FRWriteDomesticConsentData obConsentRequestData = consent.getRequestObj().getData();
+        final FRWriteDomesticDataInitiation initiation = obConsentRequestData.getInitiation();
         consentDetails.setInitiation(initiation);
         consentDetails.setInstructedAmount(initiation.getInstructedAmount());
         if (initiation.getRemittanceInformation() != null) {
@@ -93,11 +90,11 @@ public class DomesticPaymentConsentDetailsService extends BaseConsentDetailsServ
     }
 
     @VisibleForTesting
-    static FRAmount computeTotalChargeAmount(List<OBWriteDomesticConsentResponse5DataCharges> charges) {
+    static FRAmount computeTotalChargeAmount(List<FRCharge> charges) {
         String chargeCurrency = null;
         BigDecimal totalCharge = BigDecimal.ZERO;
-        for (OBWriteDomesticConsentResponse5DataCharges charge : charges) {
-            final OBActiveOrHistoricCurrencyAndAmount amount = charge.getAmount();
+        for (FRCharge charge : charges) {
+            final FRAmount amount = charge.getAmount();
             if (chargeCurrency == null) {
                 chargeCurrency = amount.getCurrency();
             } else if (!chargeCurrency.equals(amount.getCurrency())) {


### PR DESCRIPTION
Decision has been made to store the FR data model representation because OBIE introduce breaking changes often in their minor API upgrades. Using the FR data model allows us to lessen the impact of some of these issues by applying workarounds in the conversion layer.

For payments, we also store the charges (which get added to the consent response) as the FR data model representation.

Removing the requestType field from the Entity definition, as it is now redundant.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1023