### PR TITLE
1030: Adding Support for International Standing Order Consents to RCS Consent Store

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApi.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.internationalstandingorder.v3_1_10;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+
+@Validated
+@Api(tags = {"v3.1.10"})
+@RequestMapping(value = "/consent/store/v3.1.10")
+public interface InternationalStandingOrderConsentApi {
+
+    @ApiOperation(value = "Create International Standing Order Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "InternationalStandingOrderConsent object representing the consent created",
+                         response = InternationalStandingOrderConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/international-standing-order-consents",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<InternationalStandingOrderConsent> createConsent(
+            @ApiParam(value = "Create Consent Request", required = true)
+            @Valid
+            @RequestBody CreateInternationalStandingOrderConsentRequest request,
+            @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Get International Standing Order Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "InternationalStandingOrderConsent object representing the consent created",
+                         response = InternationalStandingOrderConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/international-standing-order-consents/{consentId}",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
+    ResponseEntity<InternationalStandingOrderConsent> getConsent(@PathVariable(value = "consentId") String consentId,
+                                                           @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Authorise International Standing Order Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "InternationalStandingOrderConsent object representing the consent created",
+                         response = InternationalStandingOrderConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/international-standing-order-consents/{consentId}/authorise",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<InternationalStandingOrderConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
+                                                                 @ApiParam(value = "Authorise Consent Request", required = true)
+                                                                 @Valid
+                                                                 @RequestBody AuthorisePaymentConsentRequest request,
+                                                                 @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Reject International Standing Order Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "InternationalStandingOrderConsent object representing the consent created",
+                         response = InternationalStandingOrderConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/international-standing-order-consents/{consentId}/reject",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<InternationalStandingOrderConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
+                                                              @ApiParam(value = "Reject Consent Request", required = true)
+                                                              @Valid
+                                                              @RequestBody RejectConsentRequest request,
+                                                              @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+
+    @ApiOperation(value = "Consume International Standing Order Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "InternationalStandingOrderConsent object representing the consent created",
+                         response = InternationalStandingOrderConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/international-standing-order-consents/{consentId}/consume",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<InternationalStandingOrderConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
+                                                               @ApiParam(value = "Consume Consent Request", required = true)
+                                                               @Valid
+                                                               @RequestBody ConsumePaymentConsentRequest request,
+                                                               @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.internationalstandingorder.v3_1_10;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalStandingOrderConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data.StatusEnum;
+
+/**
+ * Implementation of InternationalStandingOrderConsentApi for OBIE version 3.1.10
+ *
+ * Note: the obVersion field is pluggable, so if there are no changes to the OBIE schema in later versions, then
+ * these controllers can extend this and configure the
+ */
+@Controller
+public class InternationalStandingOrderConsentApiController implements InternationalStandingOrderConsentApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final InternationalStandingOrderConsentService consentService;
+
+    private final Supplier<DateTime> idempotencyKeyExpirationSupplier;
+
+    private final OBVersion obVersion;
+
+    @Autowired
+    public InternationalStandingOrderConsentApiController(InternationalStandingOrderConsentService consentService,
+                                                            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+        this(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
+    }
+
+    public InternationalStandingOrderConsentApiController(InternationalStandingOrderConsentService consentService,
+                                                             Supplier<DateTime> idempotencyKeyExpirationSupplier,
+                                                             OBVersion obVersion) {
+        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
+        this.idempotencyKeyExpirationSupplier = Objects.requireNonNull(idempotencyKeyExpirationSupplier, "idempotencyKeyExpirationSupplier must be provided");
+        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
+    }
+
+    @Override
+    public ResponseEntity<InternationalStandingOrderConsent> createConsent(CreateInternationalStandingOrderConsentRequest request, String apiClientId) {
+        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+        final InternationalStandingOrderConsentEntity internationalPaymentConsent = new InternationalStandingOrderConsentEntity();
+        internationalPaymentConsent.setRequestVersion(obVersion);
+        internationalPaymentConsent.setApiClientId(request.getApiClientId());
+        internationalPaymentConsent.setRequestObj(request.getConsentRequest());
+        internationalPaymentConsent.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
+        internationalPaymentConsent.setCharges(request.getCharges());
+        internationalPaymentConsent.setIdempotencyKey(request.getIdempotencyKey());
+        internationalPaymentConsent.setIdempotencyKeyExpiration(idempotencyKeyExpirationSupplier.get());
+        final InternationalStandingOrderConsentEntity persistedEntity = consentService.createConsent(internationalPaymentConsent);
+        logger.info("Consent created with id: {}", persistedEntity.getId());
+
+        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<InternationalStandingOrderConsent> getConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
+    }
+
+    @Override
+    public ResponseEntity<InternationalStandingOrderConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
+                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
+    }
+
+    @Override
+    public ResponseEntity<InternationalStandingOrderConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    }
+
+    @Override
+    public ResponseEntity<InternationalStandingOrderConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    }
+
+    private InternationalStandingOrderConsent convertEntityToDto(InternationalStandingOrderConsentEntity entity) {
+        final InternationalStandingOrderConsent dto = new InternationalStandingOrderConsent();
+        dto.setId(entity.getId());
+        dto.setStatus(entity.getStatus());
+        dto.setRequestObj(entity.getRequestObj());
+        dto.setRequestVersion(entity.getRequestVersion());
+        dto.setApiClientId(entity.getApiClientId());
+        dto.setResourceOwnerId(entity.getResourceOwnerId());
+        dto.setAuthorisedDebtorAccountId(entity.getAuthorisedDebtorAccountId());
+        dto.setIdempotencyKey(entity.getIdempotencyKey());
+        dto.setIdempotencyKeyExpiration(entity.getIdempotencyKeyExpiration());
+        dto.setCharges(entity.getCharges());
+        dto.setCreationDateTime(entity.getCreationDateTime());
+        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
+        return dto;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/BasePaymentConsentWithExchangeRateInformationApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/BasePaymentConsentWithExchangeRateInformationApiControllerTest.java
@@ -16,17 +16,17 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.api.payment;
 
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseCreateInternationalPaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseInternationalPaymentConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsentWithExchangeRateInformation;
 
-public abstract class BaseInternationalPaymentConsentApiControllerTest<T extends BaseInternationalPaymentConsent, C extends BaseCreateInternationalPaymentConsentRequest> extends BasePaymentConsentApiControllerTest<T, C> {
+public abstract class BasePaymentConsentWithExchangeRateInformationApiControllerTest<T extends BasePaymentConsentWithExchangeRateInformation, C extends BaseCreateInternationalPaymentConsentRequest> extends BasePaymentConsentApiControllerTest<T, C> {
 
-    public BaseInternationalPaymentConsentApiControllerTest(Class<T> consentClass) {
+    public BasePaymentConsentWithExchangeRateInformationApiControllerTest(Class<T> consentClass) {
         super(consentClass);
     }
 
     @Override
     protected void validateCreateConsentAgainstCreateRequest(T consent, C createConsentRequest) {
-        InternationalPaymentConsentValidationHelpers.validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+        PaymentConsentWithExchangeRateInformationValidationHelpers.validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
     }
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/PaymentConsentWithExchangeRateInformationValidationHelpers.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/PaymentConsentWithExchangeRateInformationValidationHelpers.java
@@ -20,14 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.joda.time.DateTime;
 
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseCreateInternationalPaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseInternationalPaymentConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsentWithExchangeRateInformation;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
 
-public class InternationalPaymentConsentValidationHelpers {
+public class PaymentConsentWithExchangeRateInformationValidationHelpers {
 
-    public static void validateCreateConsentAgainstCreateRequest(BaseInternationalPaymentConsent<?> consent,
+    public static void validateCreateConsentAgainstCreateRequest(BasePaymentConsentWithExchangeRateInformation<?> consent,
                                                                  BaseCreateInternationalPaymentConsentRequest<?> createConsentRequest) {
         assertThat(consent.getId()).isNotEmpty();
         assertThat(consent.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION.toString());

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiControllerTest.java
@@ -26,12 +26,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerTy
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.international.v3_1_10.CreateInternationalPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BaseInternationalPaymentConsentApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentWithExchangeRateInformationApiControllerTest;
 
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
-public class InternationalPaymentConsentApiControllerTest extends BaseInternationalPaymentConsentApiControllerTest<InternationalPaymentConsent, CreateInternationalPaymentConsentRequest> {
+public class InternationalPaymentConsentApiControllerTest extends BasePaymentConsentWithExchangeRateInformationApiControllerTest<InternationalPaymentConsent, CreateInternationalPaymentConsentRequest> {
 
     public InternationalPaymentConsentApiControllerTest() {
         super(InternationalPaymentConsent.class);

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiControllerTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.international.v3_1_10;
 
-import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BaseInternationalPaymentConsentServiceTest.getExchangeRateInformation;
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BasePaymentServiceWithExchangeRateInformationTest.getExchangeRateInformation;
 
 import java.util.List;
 import java.util.UUID;

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.internationalscheduled.v3_1_10;
 
-import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BaseInternationalPaymentConsentServiceTest.getExchangeRateInformation;
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BasePaymentServiceWithExchangeRateInformationTest.getExchangeRateInformation;
 
 import java.util.List;
 import java.util.UUID;

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
@@ -26,12 +26,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerTy
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalscheduled.v3_1_10.CreateInternationalScheduledPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BaseInternationalPaymentConsentApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentWithExchangeRateInformationApiControllerTest;
 
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory;
 
-public class InternationalScheduledPaymentConsentApiControllerTest extends BaseInternationalPaymentConsentApiControllerTest<InternationalScheduledPaymentConsent, CreateInternationalScheduledPaymentConsentRequest> {
+public class InternationalScheduledPaymentConsentApiControllerTest extends BasePaymentConsentWithExchangeRateInformationApiControllerTest<InternationalScheduledPaymentConsent, CreateInternationalScheduledPaymentConsentRequest> {
 
     public InternationalScheduledPaymentConsentApiControllerTest() {
         super(InternationalScheduledPaymentConsent.class);

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiControllerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.internationalstandingorder.v3_1_10;
+
+import java.util.UUID;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalStandingOrderConsentConverter;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
+
+public class InternationalStandingOrderConsentApiControllerTest extends BasePaymentConsentApiControllerTest<InternationalStandingOrderConsent, CreateInternationalStandingOrderConsentRequest> {
+
+    public InternationalStandingOrderConsentApiControllerTest() {
+        super(InternationalStandingOrderConsent.class);
+    }
+
+    @Override
+    protected String getControllerEndpointName() {
+        return "international-standing-order-consents";
+    }
+
+    @Override
+    protected CreateInternationalStandingOrderConsentRequest buildCreateConsentRequest(String apiClientId) {
+        return buildCreateInternationalStandingOrderConsentRequest(apiClientId, UUID.randomUUID().toString());
+    }
+
+    private static CreateInternationalStandingOrderConsentRequest buildCreateInternationalStandingOrderConsentRequest(String apiClientId, String idempotencyKey) {
+        final CreateInternationalStandingOrderConsentRequest createInternationalStandingOrderConsentRequest = new CreateInternationalStandingOrderConsentRequest();
+        final OBWriteInternationalStandingOrderConsent5 paymentConsent = OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent5();
+        createInternationalStandingOrderConsentRequest.setConsentRequest(FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent(paymentConsent));
+        createInternationalStandingOrderConsentRequest.setApiClientId(apiClientId);
+        createInternationalStandingOrderConsentRequest.setIdempotencyKey(idempotencyKey);
+        return createInternationalStandingOrderConsentRequest;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentStoreClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.internationalstandingorder.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+
+/**
+ * Client for interacting with com.forgerock.sapi.gateway.rcs.consent.store.api.v3_1_10.InternationalStandingOrderConsentApi
+ */
+public interface InternationalStandingOrderConsentStoreClient {
+
+    InternationalStandingOrderConsent createConsent(CreateInternationalStandingOrderConsentRequest createConsentRequest) throws ConsentStoreClientException;
+
+    InternationalStandingOrderConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
+    InternationalStandingOrderConsent authoriseConsent(AuthorisePaymentConsentRequest authorisePaymentConsentRequest) throws ConsentStoreClientException;
+
+    InternationalStandingOrderConsent rejectConsent(RejectConsentRequest rejectInternationalStandingOrderConsentRequest) throws ConsentStoreClientException;
+
+    InternationalStandingOrderConsent consumeConsent(ConsumePaymentConsentRequest consumePaymentConsentRequest) throws ConsentStoreClientException;
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/RestInternationalStandingOrderConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/RestInternationalStandingOrderConsentStoreClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.internationalstandingorder.v3_1_10;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.BaseRestConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientConfiguration;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+/**
+ * Implementation of the InternationalStandingOrderConsentStoreClient which makes REST calls over HTTP
+ */
+@Component
+public class RestInternationalStandingOrderConsentStoreClient extends BaseRestConsentStoreClient implements InternationalStandingOrderConsentStoreClient {
+
+    private final String consentServiceBaseUrl;
+
+    @Autowired
+    public RestInternationalStandingOrderConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration, RestTemplateBuilder restTemplateBuilder,
+                                                            ObjectMapper objectMapper) {
+        this(consentStoreClientConfiguration, restTemplateBuilder, objectMapper, OBVersion.v3_1_10);
+    }
+
+    public RestInternationalStandingOrderConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration, RestTemplateBuilder restTemplateBuilder,
+                                                            ObjectMapper objectMapper, OBVersion obVersion) {
+        super(restTemplateBuilder, objectMapper);
+        this.consentServiceBaseUrl = consentStoreClientConfiguration.getBaseUri() + "/v" + obVersion.getCanonicalVersion() + "/international-standing-order-consents";
+    }
+
+    @Override
+    public InternationalStandingOrderConsent createConsent(CreateInternationalStandingOrderConsentRequest createConsentRequest) throws ConsentStoreClientException {
+        final HttpEntity<CreateInternationalStandingOrderConsentRequest> requestEntity = new HttpEntity<>(createConsentRequest, createHeaders(createConsentRequest.getApiClientId()));
+        return doRestCall(consentServiceBaseUrl, HttpMethod.POST, requestEntity, InternationalStandingOrderConsent.class);
+    }
+
+    @Override
+    public InternationalStandingOrderConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        return doRestCall(url, HttpMethod.GET, requestEntity, InternationalStandingOrderConsent.class);
+    }
+
+    @Override
+    public InternationalStandingOrderConsent authoriseConsent(AuthorisePaymentConsentRequest authRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + authRequest.getConsentId() + "/authorise";
+        final HttpEntity<AuthorisePaymentConsentRequest> requestEntity = new HttpEntity<>(authRequest, createHeaders(authRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, InternationalStandingOrderConsent.class);
+    }
+
+    @Override
+    public InternationalStandingOrderConsent rejectConsent(RejectConsentRequest rejectRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + rejectRequest.getConsentId() + "/reject";
+        final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, InternationalStandingOrderConsent.class);
+    }
+
+    @Override
+    public InternationalStandingOrderConsent consumeConsent(ConsumePaymentConsentRequest consumeRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consumeRequest.getConsentId() + "/consume";
+        final HttpEntity<ConsumePaymentConsentRequest> requestEntity = new HttpEntity<>(consumeRequest, createHeaders(consumeRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, InternationalStandingOrderConsent.class);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/international/v3_1_10/InternationalPaymentConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/international/v3_1_10/InternationalPaymentConsentStoreClientTest.java
@@ -49,7 +49,7 @@ import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePa
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.international.v3_1_10.CreateInternationalPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BaseInternationalPaymentConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BasePaymentServiceWithExchangeRateInformationTest;
 
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data.StatusEnum;
@@ -153,7 +153,7 @@ class InternationalPaymentConsentStoreClientTest {
                         .chargeBearer(FRChargeBearerType.BORNEBYCREDITOR)
                         .amount(new FRAmount("1.25","GBP"))
                         .build()));
-        createConsentRequest.setExchangeRateInformation(BaseInternationalPaymentConsentServiceTest.getExchangeRateInformation(obConsent.getData().getInitiation().getExchangeRateInformation()));
+        createConsentRequest.setExchangeRateInformation(BasePaymentServiceWithExchangeRateInformationTest.getExchangeRateInformation(obConsent.getData().getInitiation().getExchangeRateInformation()));
         return createConsentRequest;
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentStoreClientTest.java
@@ -49,7 +49,7 @@ import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePa
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalscheduled.v3_1_10.CreateInternationalScheduledPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BaseInternationalPaymentConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.BasePaymentServiceWithExchangeRateInformationTest;
 
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data.StatusEnum;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
@@ -153,7 +153,7 @@ class InternationalScheduledPaymentConsentStoreClientTest {
                         .chargeBearer(FRChargeBearerType.BORNEBYCREDITOR)
                         .amount(new FRAmount("1.25","GBP"))
                         .build()));
-        createConsentRequest.setExchangeRateInformation(BaseInternationalPaymentConsentServiceTest.getExchangeRateInformation(obConsent.getData().getInitiation().getExchangeRateInformation()));
+        createConsentRequest.setExchangeRateInformation(BasePaymentServiceWithExchangeRateInformationTest.getExchangeRateInformation(obConsent.getData().getInitiation().getExchangeRateInformation()));
         return createConsentRequest;
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentStoreClientTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.internationalstandingorder.v3_1_10;
+
+import static com.forgerock.sapi.gateway.rcs.conent.store.client.TestConsentStoreClientConfigurationFactory.createConsentStoreClientConfiguration;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateAuthorisedConsent;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateConsumedConsent;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateCreateConsentAgainstCreateRequest;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateRejectedConsent;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerType;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalStandingOrderConsentConverter;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"rcs.consent.store.api.baseUri= 'ignored'"})
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+class InternationalStandingOrderConsentStoreClientTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private RestInternationalStandingOrderConsentStoreClient apiClient;
+
+    @BeforeEach
+    public void beforeEach() {
+        apiClient = new RestInternationalStandingOrderConsentStoreClient(createConsentStoreClientConfiguration(port), restTemplateBuilder, objectMapper);
+    }
+
+    @Test
+    void testCreateConsent() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final InternationalStandingOrderConsent consent = apiClient.createConsent(createConsentRequest);
+
+        validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Test
+    void failsToCreateConsentWhenFieldIsMissing() {
+        final CreateInternationalStandingOrderConsentRequest requestMissingIdempotencyField = buildCreateConsentRequest();
+        requestMissingIdempotencyField.setIdempotencyKey(null);
+
+        final ConsentStoreClientException clientException = assertThrows(ConsentStoreClientException.class,
+                () -> apiClient.createConsent(requestMissingIdempotencyField));
+        assertThat(clientException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(clientException.getObError1()).isNotNull();
+        assertThat(clientException.getObError1().getErrorCode()).isEqualTo("UK.OBIE.Field.Invalid");
+        assertThat(clientException.getObError1().getMessage()).isEqualTo("The field received is invalid. Reason 'must not be null'");
+        assertThat(clientException.getObError1().getPath()).isEqualTo("idempotencyKey");
+    }
+
+    @Test
+    void testAuthoriseConsent() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final InternationalStandingOrderConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final AuthorisePaymentConsentRequest authRequest = buildAuthoriseConsentRequest(consent, "psu4test", "acc-12345");
+        final InternationalStandingOrderConsent authResponse = apiClient.authoriseConsent(authRequest);
+
+        validateAuthorisedConsent(authResponse, authRequest, consent);
+    }
+
+    @Test
+    void testRejectConsent() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final InternationalStandingOrderConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final RejectConsentRequest rejectRequest = buildRejectRequest(consent, "joe.bloggs");
+        final InternationalStandingOrderConsent rejectedConsent = apiClient.rejectConsent(rejectRequest);
+        validateRejectedConsent(rejectedConsent, rejectRequest, consent);
+    }
+
+    @Test
+    void testConsumeConsent() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final InternationalStandingOrderConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final AuthorisePaymentConsentRequest authRequest = buildAuthoriseConsentRequest(consent, "psu4test", "acc-12345");
+        final InternationalStandingOrderConsent authResponse = apiClient.authoriseConsent(authRequest);
+        assertThat(authResponse.getStatus()).isEqualTo(StatusEnum.AUTHORISED.toString());
+
+        final InternationalStandingOrderConsent consumedConsent = apiClient.consumeConsent(buildConsumeRequest(consent));
+        assertThat(consumedConsent.getStatus()).isEqualTo(StatusEnum.CONSUMED.toString());
+
+        validateConsumedConsent(consumedConsent, authResponse);
+    }
+
+    @Test
+    void testGetConsent() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final InternationalStandingOrderConsent consent = apiClient.createConsent(createConsentRequest);
+        final InternationalStandingOrderConsent getResponse = apiClient.getConsent(consent.getId(), consent.getApiClientId());
+        assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
+    }
+
+    private static CreateInternationalStandingOrderConsentRequest buildCreateConsentRequest() {
+        final CreateInternationalStandingOrderConsentRequest createConsentRequest = new CreateInternationalStandingOrderConsentRequest();
+        createConsentRequest.setIdempotencyKey(UUID.randomUUID().toString());
+        createConsentRequest.setApiClientId("test-client-1");
+        createConsentRequest.setCharges(List.of(
+                FRCharge.builder().type("fee")
+                        .chargeBearer(FRChargeBearerType.BORNEBYCREDITOR)
+                        .amount(new FRAmount("1.25","GBP"))
+                        .build()));
+        createConsentRequest.setConsentRequest(FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent(OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent5()));
+        return createConsentRequest;
+    }
+
+    private static AuthorisePaymentConsentRequest buildAuthoriseConsentRequest(InternationalStandingOrderConsent consent, String resourceOwnerId, String authorisedDebtorAccountId) {
+        final AuthorisePaymentConsentRequest authRequest = new AuthorisePaymentConsentRequest();
+        authRequest.setAuthorisedDebtorAccountId(authorisedDebtorAccountId);
+        authRequest.setConsentId(consent.getId());
+        authRequest.setResourceOwnerId(resourceOwnerId);
+        authRequest.setApiClientId(consent.getApiClientId());
+        return authRequest;
+    }
+
+    private static RejectConsentRequest buildRejectRequest(InternationalStandingOrderConsent consent, String resourceOwnerId) {
+        final RejectConsentRequest rejectRequest = new RejectConsentRequest();
+        rejectRequest.setApiClientId(consent.getApiClientId());
+        rejectRequest.setConsentId(consent.getId());
+        rejectRequest.setResourceOwnerId(resourceOwnerId);
+        return rejectRequest;
+    }
+
+    private static ConsumePaymentConsentRequest buildConsumeRequest(InternationalStandingOrderConsent consent) {
+        final ConsumePaymentConsentRequest consumeRequest = new ConsumePaymentConsentRequest();
+        consumeRequest.setApiClientId(consent.getApiClientId());
+        consumeRequest.setConsentId((consent.getId()));
+        return consumeRequest;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsentWithExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsentWithExchangeRateInformation.java
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international;
+package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment;
 
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.validation.annotation.Validated;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalConsent;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 
-/**
- * OBIE International Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-payment-consents.html
- */
-@Document("InternationalPaymentConsent")
 @Validated
-public class InternationalPaymentConsentEntity extends BasePaymentConsentEntityWithExchangeRateInformation<FRWriteInternationalConsent> {
+public abstract class BasePaymentConsentWithExchangeRateInformation<T> extends BasePaymentConsent<T> {
+
+    private FRExchangeRateInformation exchangeRateInformation;
+
+    public FRExchangeRateInformation getExchangeRateInformation() {
+        return exchangeRateInformation;
+    }
+
+    public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
+        this.exchangeRateInformation = exchangeRateInformation;
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/international/v3_1_10/InternationalPaymentConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/international/v3_1_10/InternationalPaymentConsent.java
@@ -18,11 +18,11 @@ package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internatio
 import org.springframework.validation.annotation.Validated;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalConsent;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseInternationalPaymentConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsentWithExchangeRateInformation;
 
 /**
  * OBIE International Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-payment-consents.html
  */
 @Validated
-public class InternationalPaymentConsent extends BaseInternationalPaymentConsent<FRWriteInternationalConsent> {
+public class InternationalPaymentConsent extends BasePaymentConsentWithExchangeRateInformation<FRWriteInternationalConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsent.java
@@ -18,11 +18,11 @@ package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internatio
 import org.springframework.validation.annotation.Validated;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalScheduledConsent;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseInternationalPaymentConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsentWithExchangeRateInformation;
 
 /**
  * OBIE International Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-scheduled-payment-consents.html
  */
 @Validated
-public class InternationalScheduledPaymentConsent extends BaseInternationalPaymentConsent<FRWriteInternationalScheduledConsent> {
+public class InternationalScheduledPaymentConsent extends BasePaymentConsentWithExchangeRateInformation<FRWriteInternationalScheduledConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalstandingorder/v3_1_10/CreateInternationalStandingOrderConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalstandingorder/v3_1_10/CreateInternationalStandingOrderConsentRequest.java
@@ -13,22 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment;
+package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10;
 
 import org.springframework.validation.annotation.Validated;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseCreatePaymentConsentRequest;
 
 @Validated
-public abstract class BaseInternationalPaymentConsent<T> extends BasePaymentConsent<T> {
-
-    private FRExchangeRateInformation exchangeRateInformation;
-
-    public FRExchangeRateInformation getExchangeRateInformation() {
-        return exchangeRateInformation;
-    }
-
-    public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
-        this.exchangeRateInformation = exchangeRateInformation;
-    }
+public class CreateInternationalStandingOrderConsentRequest extends BaseCreatePaymentConsentRequest<FRWriteInternationalStandingOrderConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsent.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international;
+package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.internationalstandingorder.v3_1_10;
 
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.validation.annotation.Validated;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalConsent;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsent;
 
 /**
- * OBIE International Payment Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-payment-consents.html
+ * OBIE International Standing Order Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-standing-orders.html
  */
-@Document("InternationalPaymentConsent")
 @Validated
-public class InternationalPaymentConsentEntity extends BasePaymentConsentEntityWithExchangeRateInformation<FRWriteInternationalConsent> {
+public class InternationalStandingOrderConsent extends BasePaymentConsent<FRWriteInternationalStandingOrderConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/BasePaymentConsentEntityWithExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/BasePaymentConsentEntityWithExchangeRateInformation.java
@@ -22,7 +22,7 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaym
  * Payment that extends the {@link BasePaymentConsentEntity} definition with the addition of ExchangeRateInformation
  * for the transaction.
  */
-public abstract class BasePaymentWithExchangeRateInformation<T> extends BasePaymentConsentEntity<T> {
+public abstract class BasePaymentConsentEntityWithExchangeRateInformation<T> extends BasePaymentConsentEntity<T> {
 
     /**
      * Optional - used to communicate exchange rate information for the transaction

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/BasePaymentWithExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/BasePaymentWithExchangeRateInformation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaymentConsentEntity;
+
+/**
+ * Payment that extends the {@link BasePaymentConsentEntity} definition with the addition of ExchangeRateInformation
+ * for the transaction.
+ */
+public abstract class BasePaymentWithExchangeRateInformation<T> extends BasePaymentConsentEntity<T> {
+
+    /**
+     * Optional - used to communicate exchange rate information for the transaction
+     */
+    private FRExchangeRateInformation exchangeRateInformation;
+
+    public FRExchangeRateInformation getExchangeRateInformation() {
+        return exchangeRateInformation;
+    }
+
+    public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
+        this.exchangeRateInformation = exchangeRateInformation;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalPaymentConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalPaymentConsentEntity.java
@@ -25,5 +25,5 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternat
  */
 @Document("InternationalPaymentConsent")
 @Validated
-public class InternationalPaymentConsentEntity extends BaseInternationalPaymentConsentEntity<FRWriteInternationalConsent> {
+public class InternationalPaymentConsentEntity extends BasePaymentWithExchangeRateInformation<FRWriteInternationalConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalScheduledPaymentConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalScheduledPaymentConsentEntity.java
@@ -25,5 +25,5 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternat
  */
 @Document("InternationalScheduledPaymentConsent")
 @Validated
-public class InternationalScheduledPaymentConsentEntity extends BaseInternationalPaymentConsentEntity<FRWriteInternationalScheduledConsent> {
+public class InternationalScheduledPaymentConsentEntity extends BasePaymentWithExchangeRateInformation<FRWriteInternationalScheduledConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalScheduledPaymentConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalScheduledPaymentConsentEntity.java
@@ -25,5 +25,5 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternat
  */
 @Document("InternationalScheduledPaymentConsent")
 @Validated
-public class InternationalScheduledPaymentConsentEntity extends BasePaymentWithExchangeRateInformation<FRWriteInternationalScheduledConsent> {
+public class InternationalScheduledPaymentConsentEntity extends BasePaymentConsentEntityWithExchangeRateInformation<FRWriteInternationalScheduledConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalStandingOrderConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/international/InternationalStandingOrderConsentEntity.java
@@ -15,25 +15,16 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.validation.annotation.Validated;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaymentConsentEntity;
 
 /**
- * International payments extend the {@link BasePaymentConsentEntity} definition with the addition of ExchangeRateInformation
- * for the transaction.
+ * OBIE International Standing Order Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-standing-orders.html
  */
-public abstract class BaseInternationalPaymentConsentEntity<T> extends BasePaymentConsentEntity<T> {
-
-    /**
-     * Optional - used to communicate exchange rate information for the transaction
-     */
-    private FRExchangeRateInformation exchangeRateInformation;
-
-    public FRExchangeRateInformation getExchangeRateInformation() {
-        return exchangeRateInformation;
-    }
-
-    public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
-        this.exchangeRateInformation = exchangeRateInformation;
-    }
+@Document("InternationalStandingOrderConsent")
+@Validated
+public class InternationalStandingOrderConsentEntity extends BasePaymentConsentEntity<FRWriteInternationalStandingOrderConsent> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/payment/international/InternationalStandingOrderPaymentConsentRepository.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/payment/international/InternationalStandingOrderPaymentConsentRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.international;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+
+public interface InternationalStandingOrderPaymentConsentRepository extends PaymentConsentRepository<InternationalStandingOrderConsentEntity> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
+
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Service
+public class DefaultInternationalStandingOrderConsentService extends BasePaymentConsentService<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> implements InternationalStandingOrderConsentService {
+
+    public DefaultInternationalStandingOrderConsentService(PaymentConsentRepository<InternationalStandingOrderConsentEntity> repo) {
+        super(repo, IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT::generateIntentId);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalStandingOrderConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalStandingOrderConsentService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
+
+public interface InternationalStandingOrderConsentService extends PaymentConsentService<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/BasePaymentServiceWithExchangeRateInformationTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/BasePaymentServiceWithExchangeRateInformationTest.java
@@ -19,13 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.BaseInternationalPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.BasePaymentWithExchangeRateInformation;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentServiceTest;
 
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
-public abstract class BaseInternationalPaymentConsentServiceTest<T extends BaseInternationalPaymentConsentEntity<?>> extends BasePaymentConsentServiceTest<T> {
+public abstract class BasePaymentServiceWithExchangeRateInformationTest<T extends BasePaymentWithExchangeRateInformation<?>> extends BasePaymentConsentServiceTest<T> {
 
     public static FRExchangeRateInformation getExchangeRateInformation(OBWriteInternational3DataInitiationExchangeRateInformation consentRequestExchangeRateInformation) {
         if (consentRequestExchangeRateInformation.getRateType() == OBExchangeRateType2Code.AGREED) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/BasePaymentServiceWithExchangeRateInformationTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/BasePaymentServiceWithExchangeRateInformationTest.java
@@ -19,13 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.BasePaymentWithExchangeRateInformation;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.BasePaymentConsentEntityWithExchangeRateInformation;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentServiceTest;
 
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
-public abstract class BasePaymentServiceWithExchangeRateInformationTest<T extends BasePaymentWithExchangeRateInformation<?>> extends BasePaymentConsentServiceTest<T> {
+public abstract class BasePaymentServiceWithExchangeRateInformationTest<T extends BasePaymentConsentEntityWithExchangeRateInformation<?>> extends BasePaymentConsentServiceTest<T> {
 
     public static FRExchangeRateInformation getExchangeRateInformation(OBWriteInternational3DataInitiationExchangeRateInformation consentRequestExchangeRateInformation) {
         if (consentRequestExchangeRateInformation.getRateType() == OBExchangeRateType2Code.AGREED) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalScheduledPaymentConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalScheduledPaymentConsentServiceTest.java
@@ -40,7 +40,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConse
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public
-class DefaultInternationalScheduledPaymentConsentServiceTest extends BaseInternationalPaymentConsentServiceTest<InternationalScheduledPaymentConsentEntity> {
+class DefaultInternationalScheduledPaymentConsentServiceTest extends BasePaymentServiceWithExchangeRateInformationTest<InternationalScheduledPaymentConsentEntity> {
 
     @Autowired
     private DefaultInternationalScheduledPaymentConsentService consentService;

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentServiceTest.java
@@ -27,44 +27,45 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerType;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalPaymentConsentEntity;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalStandingOrderConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentServiceTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public
-class DefaultInternationalPaymentConsentServiceTest extends BasePaymentServiceWithExchangeRateInformationTest<InternationalPaymentConsentEntity> {
+class DefaultInternationalStandingOrderConsentServiceTest extends BasePaymentConsentServiceTest<InternationalStandingOrderConsentEntity> {
 
     @Autowired
-    private DefaultInternationalPaymentConsentService consentService;
+    private DefaultInternationalStandingOrderConsentService consentService;
 
     @Override
-    protected BaseConsentService<InternationalPaymentConsentEntity, PaymentAuthoriseConsentArgs> getConsentServiceToTest() {
+    protected BaseConsentService<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> getConsentServiceToTest() {
         return consentService;
     }
 
     @Override
-    protected InternationalPaymentConsentEntity getValidConsentEntity() {
+    protected InternationalStandingOrderConsentEntity getValidConsentEntity() {
         final String apiClientId = "test-client-987";
         return createValidConsentEntity(apiClientId);
     }
 
-    public static InternationalPaymentConsentEntity createValidConsentEntity(String apiClientId) {
-        return createValidConsentEntity(OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5(), apiClientId);
+    public static InternationalStandingOrderConsentEntity createValidConsentEntity(String apiClientId) {
+        return createValidConsentEntity(OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6(), apiClientId);
     }
 
-    public static InternationalPaymentConsentEntity createValidConsentEntity(OBWriteInternationalConsent5 obConsent, String apiClientId) {
-        final InternationalPaymentConsentEntity consent = new InternationalPaymentConsentEntity();
+    public static InternationalStandingOrderConsentEntity createValidConsentEntity(OBWriteInternationalStandingOrderConsent6 obConsent, String apiClientId) {
+        final InternationalStandingOrderConsentEntity consent = new InternationalStandingOrderConsentEntity();
         consent.setRequestVersion(OBVersion.v3_1_10);
         consent.setApiClientId(apiClientId);
-        consent.setRequestObj(FRWriteInternationalConsentConverter.toFRWriteInternationalConsent(obConsent));
+        consent.setRequestObj(FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent(obConsent));
         consent.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
         consent.setIdempotencyKey(UUID.randomUUID().toString());
         consent.setIdempotencyKeyExpiration(DateTime.now().plusDays(1));
@@ -78,7 +79,6 @@ class DefaultInternationalPaymentConsentServiceTest extends BasePaymentServiceWi
                         .amount(new FRAmount("0.10","GBP"))
                         .build())
         );
-        consent.setExchangeRateInformation(getExchangeRateInformation(obConsent.getData().getInitiation().getExchangeRateInformation()));
         return consent;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.international;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalStandingOrderConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Component
+public class InternationalStandingOrderConsentDecisionService extends BasePaymentConsentDecisionService<InternationalStandingOrderConsentEntity> {
+
+    public InternationalStandingOrderConsentDecisionService(InternationalStandingOrderConsentService consentService) {
+        super(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, consentService);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.international;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderConsentData;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderDataInitiation;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalStandingOrderConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.BasePaymentConsentDetailsService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.AccountService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Component
+public class InternationalStandingOrderConsentDetailsService extends BasePaymentConsentDetailsService<InternationalStandingOrderConsentEntity, InternationalStandingOrderConsentDetails> {
+
+    public InternationalStandingOrderConsentDetailsService(ConsentService<InternationalStandingOrderConsentEntity, ?> consentService,
+                                                     ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
+                                                     AccountService accountService) {
+
+        super(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, InternationalStandingOrderConsentDetails::new, consentService,
+                apiProviderConfiguration, apiClientService, accountService);
+    }
+
+    @Override
+    protected void addIntentTypeSpecificData(InternationalStandingOrderConsentDetails consentDetails,
+                                             InternationalStandingOrderConsentEntity consent,
+                                             ConsentClientDetailsRequest consentClientDetailsRequest) {
+        final FRAmount totalChargeAmount = computeTotalChargeAmount(consent.getCharges());
+        consentDetails.setCharges(totalChargeAmount);
+
+        final FRWriteInternationalStandingOrderConsentData obConsentRequestData = consent.getRequestObj().getData();
+        final FRWriteInternationalStandingOrderDataInitiation initiation = obConsentRequestData.getInitiation();
+        consentDetails.setPaymentReference(initiation.getReference());
+        consentDetails.setInitiation(initiation);
+        consentDetails.setCurrencyOfTransfer(initiation.getCurrencyOfTransfer());
+
+        addDebtorAccountDetails(consentDetails);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionServiceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.international;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalStandingOrderConsentService;
+
+@ExtendWith(MockitoExtension.class)
+public class InternationalStandingOrderConsentDecisionServiceTest extends BasePaymentConsentDecisionServiceTest<InternationalStandingOrderConsentEntity> {
+
+    @Mock
+    private InternationalStandingOrderConsentService consentService;
+
+    @InjectMocks
+    private InternationalStandingOrderConsentDecisionService decisionService;
+
+
+    @Override
+    protected PaymentConsentService<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> getPaymentConsentService() {
+        return consentService;
+    }
+
+    @Override
+    protected BasePaymentConsentDecisionService<InternationalStandingOrderConsentEntity> getConsentDecisionService() {
+        return decisionService;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
@@ -55,6 +55,7 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticSche
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticStandingOrderConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalScheduledPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalStandingOrderConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorClient;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
@@ -132,6 +133,13 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
         return consentDetails;
     }
 
+    private static InternationalStandingOrderConsentDetails createInternationalStandingOrderConsentDetails() {
+        final InternationalStandingOrderConsentDetails consentDetails = new InternationalStandingOrderConsentDetails();
+        consentDetails.setConsentId(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT.generateIntentId());
+        consentDetails.setLogo(TPP_LOGO);
+        return consentDetails;
+    }
+
     private static Stream<Arguments> validConsentDetailsArguments() {
         return Stream.of(
                 arguments(IntentType.PAYMENT_DOMESTIC_CONSENT, createDomesticPaymentConsentDetails(), DomesticPaymentConsentDetails.class),
@@ -139,7 +147,8 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
                 arguments(IntentType.PAYMENT_DOMESTIC_SCHEDULED_CONSENT, createDomesticScheduledPaymentConsentDetails(), DomesticScheduledPaymentConsentDetails.class),
                 arguments(IntentType.PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, createDomesticStandingOrderConsentDetails(), DomesticStandingOrderConsentDetails.class),
                 arguments(IntentType.PAYMENT_INTERNATIONAL_CONSENT, createInternationalPaymentConsentDetails(), InternationalPaymentConsentDetails.class),
-                arguments(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, createInternationalScheduledPaymentConsentDetails(), InternationalScheduledPaymentConsentDetails.class)
+                arguments(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, createInternationalScheduledPaymentConsentDetails(), InternationalScheduledPaymentConsentDetails.class),
+                arguments(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, createInternationalStandingOrderConsentDetails(), InternationalStandingOrderConsentDetails.class)
         );
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.international;
+
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.DefaultInternationalStandingOrderConsentServiceTest.createValidConsentEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderDataInitiation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.account.FRAccountWithBalanceTestDataFactory;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalStandingOrderConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.BasePaymentConsentDetailsServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalStandingOrderConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import com.nimbusds.jwt.SignedJWT;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
+
+@ExtendWith(MockitoExtension.class)
+class InternationalStandingOrderConsentDetailsServiceTest extends BasePaymentConsentDetailsServiceTest {
+
+    @Mock
+    private InternationalStandingOrderConsentService consentService;
+
+    @InjectMocks
+    private InternationalStandingOrderConsentDetailsService consentDetailsService;
+
+    @Test
+    void testGetInternationalStandingOrderDetails() throws ExceptionClient {
+        mockApiClientServiceResponse();
+        mockAccountServiceGetAccountsWithBalanceResponse();
+        mockApiProviderConfigurationGetName();
+
+        final String intentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+
+        final InternationalStandingOrderConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+        consentEntity.setId(intentId);
+        given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+
+        final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
+                new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(InternationalStandingOrderConsentDetails.class);
+        InternationalStandingOrderConsentDetails internationalPaymentConsentDetails = (InternationalStandingOrderConsentDetails) consentDetails;
+        assertThat(internationalPaymentConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(internationalPaymentConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+        assertThat(internationalPaymentConsentDetails.getPaymentReference()).isEqualTo("Ipsum Non Arcu Inc.");
+        assertThat(internationalPaymentConsentDetails.getCharges()).isEqualTo(new FRAmount("0.25", "GBP"));
+        assertThat(internationalPaymentConsentDetails.getCurrencyOfTransfer()).isEqualTo("USD");
+        assertThat(internationalPaymentConsentDetails.getInitiation()).isEqualTo(consentEntity.getRequestObj().getData().getInitiation());
+        assertThat(internationalPaymentConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(internationalPaymentConsentDetails.getAccounts()).isEqualTo(testUserBankAccounts);
+        assertThat(internationalPaymentConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(internationalPaymentConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(internationalPaymentConsentDetails.getUserId()).isEqualTo(testUser.getId());
+
+        assertThat(internationalPaymentConsentDetails.getDebtorAccount()).isNull();
+    }
+
+    @Test
+    public void testGetInternationalStandingOrderDetailsWithDebtorAccount() throws ExceptionClient {
+        final OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = new OBWriteDomestic2DataInitiationDebtorAccount().name("Test Account").identification("account-id-123").schemeName("accountId");
+        mockApiClientServiceResponse();
+        final FRAccountWithBalance accountWithBalance = FRAccountWithBalanceTestDataFactory.aValidFRAccountWithBalance();
+        mockAccountServiceGetByIdentifiersResponse(debtorAccount, accountWithBalance);
+        mockApiProviderConfigurationGetName();
+
+        final String intentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+
+        final InternationalStandingOrderConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+
+        consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
+        consentEntity.setId(intentId);
+        given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+
+        final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
+                new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(InternationalStandingOrderConsentDetails.class);
+        InternationalStandingOrderConsentDetails internationalPaymentConsentDetails = (InternationalStandingOrderConsentDetails) consentDetails;
+        assertThat(internationalPaymentConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(internationalPaymentConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+        assertThat(internationalPaymentConsentDetails.getPaymentReference()).isEqualTo("Ipsum Non Arcu Inc.");
+        assertThat(internationalPaymentConsentDetails.getCharges()).isEqualTo(new FRAmount("0.25", "GBP"));
+
+        final FRWriteInternationalStandingOrderDataInitiation initiation = consentEntity.getRequestObj().getData().getInitiation();
+        initiation.getDebtorAccount().setAccountId(accountWithBalance.getAccount().getAccountId());
+
+        assertThat(internationalPaymentConsentDetails.getInitiation()).isEqualTo(initiation);
+        assertThat(internationalPaymentConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(internationalPaymentConsentDetails.getAccounts()).isEqualTo(List.of(accountWithBalance));
+        assertThat(internationalPaymentConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(internationalPaymentConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(internationalPaymentConsentDetails.getUserId()).isEqualTo(testUser.getId());
+
+        assertThat(internationalPaymentConsentDetails.getDebtorAccount()).isNotNull();
+    }
+
+}


### PR DESCRIPTION
Added InternationalStandingOrderConsentEntity to the MongoDB repository, plus support in the service layer and public API.

Implemented details and decision controller logic for this payment type.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1030