### PR TITLE
1032: Adding Support for File Payment Consents to RCS Consent Store

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/DomesticVrpPaymentConsentDetails.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/DomesticVrpPaymentConsentDetails.java
@@ -16,7 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRReadRefundAccount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPControlParameters;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRWriteDomesticVrpDataInitiation;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
@@ -24,7 +24,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
 
 /**
  * Models the consent data for a domestic vrp payment.
@@ -36,8 +35,7 @@ import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
 public class DomesticVrpPaymentConsentDetails extends PaymentsConsentDetails {
 
     private FRWriteDomesticVrpDataInitiation initiation;
-    private FRReadRefundAccount readRefundAccount;
-    private OBDomesticVRPControlParameters controlParameters;
+    private FRDomesticVRPControlParameters controlParameters;
 
     @Override
     public FRAccountIdentifier getDebtorAccount() {

--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/DomesticVrpPaymentConsentDetailsFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/factory/details/DomesticVrpPaymentConsentDetailsFactory.java
@@ -15,6 +15,9 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPControlParameters;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRPeriodicLimits;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.factory.details.decoder.FRAccountIdentifierDecoder;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.json.utils.JsonUtilValidation;
@@ -29,9 +32,6 @@ import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.Instant;
 import org.springframework.stereotype.Component;
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParametersPeriodicLimits;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -115,11 +115,11 @@ public class DomesticVrpPaymentConsentDetailsFactory implements ConsentDetailsFa
         return vrpDataInitiation;
     }
 
-    private OBDomesticVRPControlParameters decodeControlParameters(JsonObject data) {
+    private FRDomesticVRPControlParameters decodeControlParameters(JsonObject data) {
         final JsonObject controlParameters = data.get(CONTROL_PARAMETERS).getAsJsonObject();
         log.debug("{}.{}.{}: {}", OB_INTENT_OBJECT, DATA, CONTROL_PARAMETERS, controlParameters);
 
-        OBDomesticVRPControlParameters ctrlParams = new OBDomesticVRPControlParameters();
+        FRDomesticVRPControlParameters ctrlParams = new FRDomesticVRPControlParameters();
 
         if (JsonUtilValidation.isNotNull(controlParameters.get(VALID_FROM_DATETIME))) {
             ctrlParams.setValidFromDateTime(Instant.parse(controlParameters.get(VALID_FROM_DATETIME).getAsString()).toDateTime());
@@ -133,12 +133,12 @@ public class DomesticVrpPaymentConsentDetailsFactory implements ConsentDetailsFa
                 controlParameters.get(VRP_TYPE), new TypeToken<List<String>>() {
                 }.getType()
         );
-        ctrlParams.setVrPType(vrpTypeList);
+        ctrlParams.setVrpType(vrpTypeList);
         List<String> vrpAuthMethodsList = new Gson().fromJson(
                 controlParameters.get(PSU_AUTHENTICATION_METHODS), new TypeToken<List<String>>() {
                 }.getType()
         );
-        ctrlParams.setPsUAuthenticationMethods(vrpAuthMethodsList);
+        ctrlParams.setPsuAuthenticationMethods(vrpAuthMethodsList);
 
         if (JsonUtilValidation.isNotNull(controlParameters.get(MAXIMUM_INDIVIDUAL_AMOUNT))) {
             ctrlParams.setMaximumIndividualAmount(decodeMaximumIndividualAmount(controlParameters));
@@ -150,32 +150,32 @@ public class DomesticVrpPaymentConsentDetailsFactory implements ConsentDetailsFa
         return ctrlParams;
     }
 
-    private OBActiveOrHistoricCurrencyAndAmount decodeMaximumIndividualAmount(JsonObject controlParameters) {
+    private FRAmount decodeMaximumIndividualAmount(JsonObject controlParameters) {
         final JsonObject maximumIndividualAmount = controlParameters.get(MAXIMUM_INDIVIDUAL_AMOUNT).getAsJsonObject();
         log.debug("{}.{}.{}.{}: {}", OB_INTENT_OBJECT, DATA, CONTROL_PARAMETERS, MAXIMUM_INDIVIDUAL_AMOUNT, maximumIndividualAmount);
-        OBActiveOrHistoricCurrencyAndAmount maxIndividualAmount = new OBActiveOrHistoricCurrencyAndAmount();
+        FRAmount maxIndividualAmount = new FRAmount();
         maxIndividualAmount.setAmount(maximumIndividualAmount.get(AMOUNT).getAsString());
         maxIndividualAmount.setCurrency(maximumIndividualAmount.get(CURRENCY).getAsString());
         return maxIndividualAmount;
     }
 
-    private List<OBDomesticVRPControlParametersPeriodicLimits> decodePeriodicLimits(JsonObject controlParameters) {
+    private List<FRPeriodicLimits> decodePeriodicLimits(JsonObject controlParameters) {
         final JsonArray periodicLimits = controlParameters.get(PERIODIC_LIMITS).getAsJsonArray();
         log.debug("{}.{}.{}.{}: {}", OB_INTENT_OBJECT, DATA, CONTROL_PARAMETERS, PERIODIC_LIMITS, periodicLimits);
-        List<OBDomesticVRPControlParametersPeriodicLimits> periodicLimitsList = new ArrayList<>();
+        List<FRPeriodicLimits> periodicLimitsList = new ArrayList<>();
         for (JsonElement periodicLimit : periodicLimits) {
             JsonObject periodicLimitObj = periodicLimit.getAsJsonObject();
             if (periodicLimitObj != null) {
-                OBDomesticVRPControlParametersPeriodicLimits periodicLimitElement = new OBDomesticVRPControlParametersPeriodicLimits();
+                FRPeriodicLimits periodicLimitElement = new FRPeriodicLimits();
                 periodicLimitElement.setAmount(periodicLimitObj.get(AMOUNT).getAsString());
                 periodicLimitElement.setCurrency(periodicLimitObj.get(CURRENCY).getAsString());
                 periodicLimitElement.setPeriodAlignment(
-                        OBDomesticVRPControlParametersPeriodicLimits.PeriodAlignmentEnum.fromValue(
+                        FRPeriodicLimits.PeriodAlignmentEnum.fromValue(
                                 periodicLimitObj.get(PERIOD_ALIGNMENT).getAsString()
                         )
                 );
                 periodicLimitElement.setPeriodType(
-                        OBDomesticVRPControlParametersPeriodicLimits.PeriodTypeEnum.fromValue(
+                        FRPeriodicLimits.PeriodTypeEnum.fromValue(
                                 periodicLimitObj.get(PERIOD_TYPE).getAsString()
                         )
                 );

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.vrp.v3_1_10;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+
+@Validated
+@Api(tags = {"v3.1.10"})
+@RequestMapping(value = "/consent/store/v3.1.10")
+public interface DomesticVRPConsentApi {
+
+    @ApiOperation(value = "Create Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "DomesticVRPConsent object representing the consent created",
+                         response = DomesticVRPConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<DomesticVRPConsent> createConsent(
+            @ApiParam(value = "Create Consent Request", required = true)
+            @Valid
+            @RequestBody CreateDomesticVRPConsentRequest request,
+            @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Get Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "DomesticVRPConsent object representing the consent created",
+                         response = DomesticVRPConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents/{consentId}",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
+    ResponseEntity<DomesticVRPConsent> getConsent(@PathVariable(value = "consentId") String consentId,
+                                                      @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Authorise Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "DomesticVRPConsent object representing the consent created",
+                         response = DomesticVRPConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents/{consentId}/authorise",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<DomesticVRPConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
+                                                            @ApiParam(value = "Authorise Consent Request", required = true)
+                                                            @Valid
+                                                            @RequestBody AuthorisePaymentConsentRequest request,
+                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Reject Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "DomesticVRPConsent object representing the consent created",
+                         response = DomesticVRPConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents/{consentId}/reject",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<DomesticVRPConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
+                                                         @ApiParam(value = "Reject Consent Request", required = true)
+                                                         @Valid
+                                                         @RequestBody RejectConsentRequest request,
+                                                         @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+
+    @ApiOperation(value = "Consume Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "DomesticVRPConsent object representing the consent created",
+                         response = DomesticVRPConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents/{consentId}/consume",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<DomesticVRPConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
+                                                          @ApiParam(value = "Consume Consent Request", required = true)
+                                                          @Valid
+                                                          @RequestBody ConsumePaymentConsentRequest request,
+                                                          @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.vrp.v3_1_10;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
+
+/**
+ * Implementation of DomesticVRPConsentApi for OBIE version 3.1.10
+ *
+ * Note: the obVersion field is pluggable, so if there are no changes to the OBIE schema in later versions, then
+ * these controllers can extend this and configure the
+ */
+@Controller
+public class DomesticVRPConsentApiController implements DomesticVRPConsentApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DomesticVRPConsentService consentService;
+
+    private final Supplier<DateTime> idempotencyKeyExpirationSupplier;
+
+    private final OBVersion obVersion;
+
+    @Autowired
+    public DomesticVRPConsentApiController(DomesticVRPConsentService consentService,
+                                           Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+        this(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
+    }
+
+    public DomesticVRPConsentApiController(DomesticVRPConsentService consentService,
+                                               Supplier<DateTime> idempotencyKeyExpirationSupplier,
+                                               OBVersion obVersion) {
+        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
+        this.idempotencyKeyExpirationSupplier = Objects.requireNonNull(idempotencyKeyExpirationSupplier, "idempotencyKeyExpirationSupplier must be provided");
+        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
+    }
+
+    @Override
+    public ResponseEntity<DomesticVRPConsent> createConsent(CreateDomesticVRPConsentRequest request, String apiClientId) {
+        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+        final DomesticVRPConsentEntity domesticPaymentConsent = new DomesticVRPConsentEntity();
+        domesticPaymentConsent.setRequestVersion(obVersion);
+        domesticPaymentConsent.setApiClientId(request.getApiClientId());
+        domesticPaymentConsent.setRequestObj(request.getConsentRequest());
+        domesticPaymentConsent.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
+        domesticPaymentConsent.setCharges(request.getCharges());
+        domesticPaymentConsent.setIdempotencyKey(request.getIdempotencyKey());
+        domesticPaymentConsent.setIdempotencyKeyExpiration(idempotencyKeyExpirationSupplier.get());
+        final DomesticVRPConsentEntity persistedEntity = consentService.createConsent(domesticPaymentConsent);
+        logger.info("Consent created with id: {}", persistedEntity.getId());
+
+        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<DomesticVRPConsent> getConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
+    }
+
+    @Override
+    public ResponseEntity<DomesticVRPConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
+                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
+    }
+
+    @Override
+    public ResponseEntity<DomesticVRPConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    }
+
+    @Override
+    public ResponseEntity<DomesticVRPConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    }
+
+    private DomesticVRPConsent convertEntityToDto(DomesticVRPConsentEntity entity) {
+        final DomesticVRPConsent dto = new DomesticVRPConsent();
+        dto.setId(entity.getId());
+        dto.setStatus(entity.getStatus());
+        dto.setRequestObj(entity.getRequestObj());
+        dto.setRequestVersion(entity.getRequestVersion());
+        dto.setApiClientId(entity.getApiClientId());
+        dto.setResourceOwnerId(entity.getResourceOwnerId());
+        dto.setAuthorisedDebtorAccountId(entity.getAuthorisedDebtorAccountId());
+        dto.setIdempotencyKey(entity.getIdempotencyKey());
+        dto.setIdempotencyKeyExpiration(entity.getIdempotencyKeyExpiration());
+        dto.setCharges(entity.getCharges());
+        dto.setCreationDateTime(entity.getCreationDateTime());
+        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
+        return dto;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.vrp.v3_1_10;
+
+import java.util.UUID;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
+
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
+
+
+public class DomesticVRPConsentApiControllerTest extends BasePaymentConsentApiControllerTest<DomesticVRPConsent, CreateDomesticVRPConsentRequest> {
+
+    public DomesticVRPConsentApiControllerTest() {
+        super(DomesticVRPConsent.class);
+    }
+
+    @Override
+    protected String getControllerEndpointName() {
+        return "domestic-vrp-consents";
+    }
+
+    @Override
+    protected CreateDomesticVRPConsentRequest buildCreateConsentRequest(String apiClientId) {
+        return buildCreateDomesticVRPConsentRequest(apiClientId, UUID.randomUUID().toString());
+    }
+
+    private static CreateDomesticVRPConsentRequest buildCreateDomesticVRPConsentRequest(String apiClientId, String idempotencyKey) {
+        final CreateDomesticVRPConsentRequest createDomesticVRPConsentRequest = new CreateDomesticVRPConsentRequest();
+        final OBDomesticVRPConsentRequest paymentConsent = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest();
+        createDomesticVRPConsentRequest.setConsentRequest(FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(paymentConsent));
+        createDomesticVRPConsentRequest.setApiClientId(apiClientId);
+        createDomesticVRPConsentRequest.setIdempotencyKey(idempotencyKey);
+        return createDomesticVRPConsentRequest;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.vrp.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+
+/**
+ * Client for interacting with com.forgerock.sapi.gateway.rcs.consent.store.api.v3_1_10.DomesticVRPConsentApi
+ */
+public interface DomesticVRPConsentStoreClient {
+
+    DomesticVRPConsent createConsent(CreateDomesticVRPConsentRequest createConsentRequest) throws ConsentStoreClientException;
+
+    DomesticVRPConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
+    DomesticVRPConsent authoriseConsent(AuthorisePaymentConsentRequest authorisePaymentConsentRequest) throws ConsentStoreClientException;
+
+    DomesticVRPConsent rejectConsent(RejectConsentRequest rejectDomesticVRPConsentRequest) throws ConsentStoreClientException;
+
+    DomesticVRPConsent consumeConsent(ConsumePaymentConsentRequest consumePaymentConsentRequest) throws ConsentStoreClientException;
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.vrp.v3_1_10;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.BaseRestConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientConfiguration;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+/**
+ * Implementation of the DomesticVRPConsentStoreClient which makes REST calls over HTTP
+ */
+@Component
+public class RestDomesticVRPConsentStoreClient extends BaseRestConsentStoreClient implements DomesticVRPConsentStoreClient {
+
+    private final String consentServiceBaseUrl;
+
+    @Autowired
+    public RestDomesticVRPConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration, RestTemplateBuilder restTemplateBuilder,
+                                                 ObjectMapper objectMapper) {
+        this(consentStoreClientConfiguration, restTemplateBuilder, objectMapper, OBVersion.v3_1_10);
+    }
+
+    public RestDomesticVRPConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration, RestTemplateBuilder restTemplateBuilder,
+                                                 ObjectMapper objectMapper, OBVersion obVersion) {
+        super(restTemplateBuilder, objectMapper);
+        this.consentServiceBaseUrl = consentStoreClientConfiguration.getBaseUri() + "/v" + obVersion.getCanonicalVersion() + "/domestic-vrp-consents";
+    }
+
+    @Override
+    public DomesticVRPConsent createConsent(CreateDomesticVRPConsentRequest createConsentRequest) throws ConsentStoreClientException {
+        final HttpEntity<CreateDomesticVRPConsentRequest> requestEntity = new HttpEntity<>(createConsentRequest, createHeaders(createConsentRequest.getApiClientId()));
+        return doRestCall(consentServiceBaseUrl, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
+    }
+
+    @Override
+    public DomesticVRPConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        return doRestCall(url, HttpMethod.GET, requestEntity, DomesticVRPConsent.class);
+    }
+
+    @Override
+    public DomesticVRPConsent authoriseConsent(AuthorisePaymentConsentRequest authRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + authRequest.getConsentId() + "/authorise";
+        final HttpEntity<AuthorisePaymentConsentRequest> requestEntity = new HttpEntity<>(authRequest, createHeaders(authRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
+    }
+
+    @Override
+    public DomesticVRPConsent rejectConsent(RejectConsentRequest rejectRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + rejectRequest.getConsentId() + "/reject";
+        final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
+    }
+
+    @Override
+    public DomesticVRPConsent consumeConsent(ConsumePaymentConsentRequest consumeRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consumeRequest.getConsentId() + "/consume";
+        final HttpEntity<ConsumePaymentConsentRequest> requestEntity = new HttpEntity<>(consumeRequest, createHeaders(consumeRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.vrp.v3_1_10;
+
+import static com.forgerock.sapi.gateway.rcs.conent.store.client.TestConsentStoreClientConfigurationFactory.createConsentStoreClientConfiguration;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateAuthorisedConsent;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateConsumedConsent;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateCreateConsentAgainstCreateRequest;
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateRejectedConsent;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerType;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"rcs.consent.store.api.baseUri= 'ignored'"})
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+class DomesticVRPConsentStoreClientTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private RestDomesticVRPConsentStoreClient apiClient;
+
+    @BeforeEach
+    public void beforeEach() {
+        apiClient = new RestDomesticVRPConsentStoreClient(createConsentStoreClientConfiguration(port), restTemplateBuilder, objectMapper);
+    }
+
+    @Test
+    void testCreateConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+
+        validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Test
+    void failsToCreateConsentWhenFieldIsMissing() {
+        final CreateDomesticVRPConsentRequest requestMissingIdempotencyField = buildCreateConsentRequest();
+        requestMissingIdempotencyField.setIdempotencyKey(null);
+
+        final ConsentStoreClientException clientException = assertThrows(ConsentStoreClientException.class,
+                () -> apiClient.createConsent(requestMissingIdempotencyField));
+        assertThat(clientException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(clientException.getObError1()).isNotNull();
+        assertThat(clientException.getObError1().getErrorCode()).isEqualTo("UK.OBIE.Field.Invalid");
+        assertThat(clientException.getObError1().getMessage()).isEqualTo("The field received is invalid. Reason 'must not be null'");
+        assertThat(clientException.getObError1().getPath()).isEqualTo("idempotencyKey");
+    }
+
+    @Test
+    void testAuthoriseConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final AuthorisePaymentConsentRequest authRequest = buildAuthoriseConsentRequest(consent, "psu4test", "acc-12345");
+        final DomesticVRPConsent authResponse = apiClient.authoriseConsent(authRequest);
+
+        validateAuthorisedConsent(authResponse, authRequest, consent);
+    }
+
+    @Test
+    void testRejectConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final RejectConsentRequest rejectRequest = buildRejectRequest(consent, "joe.bloggs");
+        final DomesticVRPConsent rejectedConsent = apiClient.rejectConsent(rejectRequest);
+        validateRejectedConsent(rejectedConsent, rejectRequest, consent);
+    }
+
+    @Test
+    void testConsumeConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+
+        final AuthorisePaymentConsentRequest authRequest = buildAuthoriseConsentRequest(consent, "psu4test", "acc-12345");
+        final DomesticVRPConsent authResponse = apiClient.authoriseConsent(authRequest);
+        assertThat(authResponse.getStatus()).isEqualTo(StatusEnum.AUTHORISED.toString());
+
+        final DomesticVRPConsent consumedConsent = apiClient.consumeConsent(buildConsumeRequest(consent));
+        assertThat(consumedConsent.getStatus()).isEqualTo(StatusEnum.CONSUMED.toString());
+
+        validateConsumedConsent(consumedConsent, authResponse);
+    }
+
+    @Test
+    void testGetConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+        final DomesticVRPConsent getResponse = apiClient.getConsent(consent.getId(), consent.getApiClientId());
+        assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
+    }
+
+    private static CreateDomesticVRPConsentRequest buildCreateConsentRequest() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = new CreateDomesticVRPConsentRequest();
+        createConsentRequest.setIdempotencyKey(UUID.randomUUID().toString());
+        createConsentRequest.setApiClientId("test-client-1");
+        createConsentRequest.setConsentRequest(FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest()));
+        createConsentRequest.setCharges(List.of(
+                FRCharge.builder().type("fee")
+                        .chargeBearer(FRChargeBearerType.BORNEBYCREDITOR)
+                        .amount(new FRAmount("1.25","GBP"))
+                        .build()));
+        return createConsentRequest;
+    }
+
+    private static AuthorisePaymentConsentRequest buildAuthoriseConsentRequest(DomesticVRPConsent consent, String resourceOwnerId, String authorisedDebtorAccountId) {
+        final AuthorisePaymentConsentRequest authRequest = new AuthorisePaymentConsentRequest();
+        authRequest.setAuthorisedDebtorAccountId(authorisedDebtorAccountId);
+        authRequest.setConsentId(consent.getId());
+        authRequest.setResourceOwnerId(resourceOwnerId);
+        authRequest.setApiClientId(consent.getApiClientId());
+        return authRequest;
+    }
+
+    private static RejectConsentRequest buildRejectRequest(DomesticVRPConsent consent, String resourceOwnerId) {
+        final RejectConsentRequest rejectRequest = new RejectConsentRequest();
+        rejectRequest.setApiClientId(consent.getApiClientId());
+        rejectRequest.setConsentId(consent.getId());
+        rejectRequest.setResourceOwnerId(resourceOwnerId);
+        return rejectRequest;
+    }
+
+    private static ConsumePaymentConsentRequest buildConsumeRequest(DomesticVRPConsent consent) {
+        final ConsumePaymentConsentRequest consumeRequest = new ConsumePaymentConsentRequest();
+        consumeRequest.setApiClientId(consent.getApiClientId());
+        consumeRequest.setConsentId((consent.getId()));
+        return consumeRequest;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/vrp/v3_1_10/CreateDomesticVRPConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/vrp/v3_1_10/CreateDomesticVRPConsentRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BaseCreatePaymentConsentRequest;
+
+@Validated
+public class CreateDomesticVRPConsentRequest extends BaseCreatePaymentConsentRequest<FRDomesticVRPConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/vrp/v3_1_10/DomesticVRPConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/vrp/v3_1_10/DomesticVRPConsent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.BasePaymentConsent;
+
+/**
+ * OBIE Domestic VRP Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html
+ */
+@Validated
+public class DomesticVRPConsent extends BasePaymentConsent<FRDomesticVRPConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/vrp/DomesticVRPConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/payment/vrp/DomesticVRPConsentEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.validation.annotation.Validated;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaymentConsentEntity;
+
+/**
+ * OBIE Domestic VRP Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html
+ */
+@Document("DomesticVRPConsent")
+@Validated
+public class DomesticVRPConsentEntity extends BasePaymentConsentEntity<FRDomesticVRPConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/payment/vrp/DomesticVRPConsentRepository.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/payment/vrp/DomesticVRPConsentRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.vrp;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+
+public interface DomesticVRPConsentRepository  extends PaymentConsentRepository<DomesticVRPConsentEntity> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
+
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Service
+public class DefaultDomesticVRPConsentService extends BasePaymentConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> implements DomesticVRPConsentService {
+
+    protected DefaultDomesticVRPConsentService(PaymentConsentRepository<DomesticVRPConsentEntity> repo) {
+        super(repo, IntentType.DOMESTIC_VRP_PAYMENT_CONSENT::generateIntentId);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
+
+public interface DomesticVRPConsentService extends PaymentConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerType;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class DefaultDomesticVRPConsentServiceTest extends BasePaymentConsentServiceTest<DomesticVRPConsentEntity> {
+
+    @Autowired
+    private DefaultDomesticVRPConsentService service;
+
+    @Override
+    protected BaseConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> getConsentServiceToTest() {
+        return service;
+    }
+
+    @Override
+    protected DomesticVRPConsentEntity getValidConsentEntity() {
+        final String apiClientId = "test-client-987";
+        return createValidConsentEntity(apiClientId);
+    }
+
+    public static DomesticVRPConsentEntity createValidConsentEntity(String apiClientId) {
+        return createValidConsentEntity(OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest(), apiClientId);
+    }
+
+    public static DomesticVRPConsentEntity createValidConsentEntity(OBDomesticVRPConsentRequest obConsent, String apiClientId) {
+        final DomesticVRPConsentEntity vrpConsent = new DomesticVRPConsentEntity();
+        vrpConsent.setRequestVersion(OBVersion.v3_1_10);
+        vrpConsent.setApiClientId(apiClientId);
+        vrpConsent.setRequestObj(FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(obConsent));
+        vrpConsent.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
+        vrpConsent.setIdempotencyKey(UUID.randomUUID().toString());
+        vrpConsent.setIdempotencyKeyExpiration(DateTime.now().plusDays(1));
+        vrpConsent.setCharges(List.of(
+                FRCharge.builder().type("fee1")
+                        .chargeBearer(FRChargeBearerType.BORNEBYDEBTOR)
+                        .amount(new FRAmount("0.15","GBP"))
+                        .build(),
+                FRCharge.builder().type("fee2")
+                        .chargeBearer(FRChargeBearerType.BORNEBYDEBTOR)
+                        .amount(new FRAmount("0.10","GBP"))
+                        .build())
+        );
+        return vrpConsent;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.vrp;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Component
+public class DomesticVRPConsentDecisionService extends BasePaymentConsentDecisionService<DomesticVRPConsentEntity> {
+
+    public DomesticVRPConsentDecisionService(DomesticVRPConsentService consentService) {
+        super(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, consentService);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.vrp;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsentData;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRWriteDomesticVrpDataInitiation;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.BasePaymentConsentDetailsService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.AccountService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+@Component
+public class DomesticVRPConsentDetailsService extends BasePaymentConsentDetailsService<DomesticVRPConsentEntity, DomesticVrpPaymentConsentDetails> {
+
+    public DomesticVRPConsentDetailsService(ConsentService<DomesticVRPConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
+            AccountService accountService) {
+
+        super(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, DomesticVrpPaymentConsentDetails::new, consentService,
+                apiProviderConfiguration, apiClientService, accountService);
+    }
+
+    @Override
+    protected void addIntentTypeSpecificData(DomesticVrpPaymentConsentDetails consentDetails, DomesticVRPConsentEntity consent,
+                                             ConsentClientDetailsRequest consentClientDetailsRequest) {
+
+        final FRDomesticVRPConsentData obConsentRequestData = consent.getRequestObj().getData();
+        final FRWriteDomesticVrpDataInitiation initiation = obConsentRequestData.getInitiation();
+        consentDetails.setInitiation(initiation);
+        consentDetails.setControlParameters(obConsentRequestData.getControlParameters());
+
+        addDebtorAccountDetails(consentDetails);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionServiceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.vrp;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
+
+@ExtendWith(MockitoExtension.class)
+public class DomesticVRPConsentDecisionServiceTest extends BasePaymentConsentDecisionServiceTest<DomesticVRPConsentEntity> {
+
+    @Mock
+    private DomesticVRPConsentService domesticPaymentConsentService;
+
+    @InjectMocks
+    private DomesticVRPConsentDecisionService domesticPaymentConsentDecisionService;
+
+
+    @Override
+    protected PaymentConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> getPaymentConsentService() {
+        return domesticPaymentConsentService;
+    }
+
+    @Override
+    protected BasePaymentConsentDecisionService<DomesticVRPConsentEntity> getConsentDecisionService() {
+        return domesticPaymentConsentDecisionService;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
@@ -53,6 +53,7 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetai
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticScheduledPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticStandingOrderConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.FilePaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalPaymentConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalScheduledPaymentConsentDetails;
@@ -148,6 +149,13 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
         return filePaymentConsentDetails;
     }
 
+    private static DomesticVrpPaymentConsentDetails createVrpConsentDetails() {
+        final DomesticVrpPaymentConsentDetails consentDetails = new DomesticVrpPaymentConsentDetails();
+        consentDetails.setConsentId(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT.generateIntentId());
+        consentDetails.setLogo(TPP_LOGO);
+        return consentDetails;
+    }
+
     private static Stream<Arguments> validConsentDetailsArguments() {
         return Stream.of(
                 arguments(IntentType.PAYMENT_DOMESTIC_CONSENT, createDomesticPaymentConsentDetails(), DomesticPaymentConsentDetails.class),
@@ -157,7 +165,8 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
                 arguments(IntentType.PAYMENT_INTERNATIONAL_CONSENT, createInternationalPaymentConsentDetails(), InternationalPaymentConsentDetails.class),
                 arguments(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, createInternationalScheduledPaymentConsentDetails(), InternationalScheduledPaymentConsentDetails.class),
                 arguments(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, createInternationalStandingOrderConsentDetails(), InternationalStandingOrderConsentDetails.class),
-                arguments(IntentType.PAYMENT_FILE_CONSENT, createFilePaymentConsentDetails(), FilePaymentConsentDetails.class)
+                arguments(IntentType.PAYMENT_FILE_CONSENT, createFilePaymentConsentDetails(), FilePaymentConsentDetails.class),
+                arguments(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, createVrpConsentDetails(), DomesticVrpPaymentConsentDetails.class)
         );
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsServiceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.vrp;
+
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DefaultDomesticVRPConsentServiceTest.createValidConsentEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.account.FRAccountWithBalanceTestDataFactory;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRWriteDomesticVrpDataInitiation;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.BasePaymentConsentDetailsServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import com.nimbusds.jwt.SignedJWT;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
+
+@ExtendWith(MockitoExtension.class)
+class DomesticVRPConsentDetailsServiceTest extends BasePaymentConsentDetailsServiceTest {
+
+    @Mock
+    private DomesticVRPConsentService consentService;
+
+    @InjectMocks
+    private DomesticVRPConsentDetailsService consentDetailsService;
+
+    @Test
+    void testGetDomesticVRPDetails() throws ExceptionClient {
+        mockApiClientServiceResponse();
+        mockAccountServiceGetAccountsWithBalanceResponse();
+        mockApiProviderConfigurationGetName();
+
+        final String intentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+
+        final DomesticVRPConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+        consentEntity.setId(intentId);
+        given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+
+        final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
+                new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(DomesticVrpPaymentConsentDetails.class);
+        DomesticVrpPaymentConsentDetails vrpConsentDetails = (DomesticVrpPaymentConsentDetails) consentDetails;
+        assertThat(vrpConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(vrpConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+        assertThat(vrpConsentDetails.getInitiation()).isEqualTo(consentEntity.getRequestObj().getData().getInitiation());
+        assertThat(vrpConsentDetails.getControlParameters()).isEqualTo(consentEntity.getRequestObj().getData().getControlParameters());
+        assertThat(vrpConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(vrpConsentDetails.getAccounts()).isEqualTo(testUserBankAccounts);
+        assertThat(vrpConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(vrpConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(vrpConsentDetails.getUserId()).isEqualTo(testUser.getId());
+
+        assertThat(vrpConsentDetails.getDebtorAccount()).isNull();
+    }
+
+    @Test
+    public void testGetDomesticVRPDetailsWithDebtorAccount() throws ExceptionClient {
+        final OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = new OBWriteDomestic2DataInitiationDebtorAccount().name("Test Account").identification("account-id-123").schemeName("accountId");
+        mockApiClientServiceResponse();
+        final FRAccountWithBalance accountWithBalance = FRAccountWithBalanceTestDataFactory.aValidFRAccountWithBalance();
+        mockAccountServiceGetByIdentifiersResponse(debtorAccount, accountWithBalance);
+        mockApiProviderConfigurationGetName();
+
+        final String intentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+
+        final DomesticVRPConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+
+        consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
+        consentEntity.setId(intentId);
+        given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+
+        final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
+                new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(DomesticVrpPaymentConsentDetails.class);
+        DomesticVrpPaymentConsentDetails vrpConsentDetails = (DomesticVrpPaymentConsentDetails) consentDetails;
+        assertThat(vrpConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(vrpConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+
+        final FRWriteDomesticVrpDataInitiation initiation = consentEntity.getRequestObj().getData().getInitiation();
+        initiation.getDebtorAccount().setAccountId(accountWithBalance.getAccount().getAccountId());
+
+        assertThat(vrpConsentDetails.getInitiation()).isEqualTo(initiation);
+        assertThat(vrpConsentDetails.getControlParameters()).isEqualTo(consentEntity.getRequestObj().getData().getControlParameters());
+        assertThat(vrpConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(vrpConsentDetails.getAccounts()).isEqualTo(List.of(accountWithBalance));
+        assertThat(vrpConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(vrpConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(vrpConsentDetails.getUserId()).isEqualTo(testUser.getId());
+
+        assertThat(vrpConsentDetails.getDebtorAccount()).isNotNull();
+    }
+
+}


### PR DESCRIPTION
Added DomesticVRPConsentEntity to the MongoDB repository, plus support in the service layer and public API.

Implemented details and decision controller logic for this payment type.

Changing the DomesticVrpPaymentConsentDetails to use the FR data model types (rather than OB), and removed the unused readRefundAccount field

https://github.com/SecureApiGateway/SecureApiGateway/issues/1032