### PR TITLE
1032: Removing x-api-client-id header from Consent Store API POST endpoints

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
@@ -58,11 +58,9 @@ public interface AccountAccessConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<AccountAccessConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateAccountAccessConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<AccountAccessConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                       @Valid
+                                                       @RequestBody CreateAccountAccessConsentRequest request);
 
 
     @ApiOperation(value = "Get Account Access Consent")
@@ -80,7 +78,7 @@ public interface AccountAccessConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<AccountAccessConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                    @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise Account Access Consent")
@@ -99,10 +97,9 @@ public interface AccountAccessConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<AccountAccessConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-            @ApiParam(value = "Authorise Consent Request", required = true)
-            @Valid
-            @RequestBody AuthoriseAccountAccessConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                          @ApiParam(value = "Authorise Consent Request", required = true)
+                                                          @Valid
+                                                          @RequestBody AuthoriseAccountAccessConsentRequest request);
 
 
     @ApiOperation(value = "Reject Account Access Consent")
@@ -121,9 +118,8 @@ public interface AccountAccessConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<AccountAccessConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-            @ApiParam(value = "Reject Consent Request", required = true)
-            @Valid
-            @RequestBody RejectConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                       @ApiParam(value = "Reject Consent Request", required = true)
+                                                       @Valid
+                                                       @RequestBody RejectConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
@@ -55,11 +55,11 @@ public class AccountAccessConsentApiController implements AccountAccessConsentAp
     }
 
     @Override
-    public ResponseEntity<AccountAccessConsent> createConsent(CreateAccountAccessConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<AccountAccessConsent> createConsent(CreateAccountAccessConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final AccountAccessConsentEntity consentEntity = new AccountAccessConsentEntity();
         consentEntity.setRequestObj(request.getConsentRequest());
-        consentEntity.setApiClientId(apiClientId);
+        consentEntity.setApiClientId(request.getApiClientId());
         consentEntity.setRequestVersion(obVersion);
         consentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
 
@@ -76,17 +76,17 @@ public class AccountAccessConsentApiController implements AccountAccessConsentAp
     }
 
     @Override
-    public ResponseEntity<AccountAccessConsent> authoriseConsent(String consentId, AuthoriseAccountAccessConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final AccountAccessAuthoriseConsentArgs authoriseArgs = new AccountAccessAuthoriseConsentArgs(consentId, apiClientId,
+    public ResponseEntity<AccountAccessConsent> authoriseConsent(String consentId, AuthoriseAccountAccessConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final AccountAccessAuthoriseConsentArgs authoriseArgs = new AccountAccessAuthoriseConsentArgs(consentId, request.getApiClientId(),
                 request.getResourceOwnerId(), request.getAuthorisedAccountIds());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(authoriseArgs)));
     }
 
     @Override
-    public ResponseEntity<AccountAccessConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<AccountAccessConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     private AccountAccessConsent convertEntityToDto(AccountAccessConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApi.java
@@ -58,11 +58,9 @@ public interface DomesticPaymentConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<DomesticPaymentConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateDomesticPaymentConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<DomesticPaymentConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                         @Valid
+                                                         @RequestBody CreateDomesticPaymentConsentRequest request);
 
 
     @ApiOperation(value = "Get Domestic Payment Consent")
@@ -101,8 +99,7 @@ public interface DomesticPaymentConsentApi {
     ResponseEntity<DomesticPaymentConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
                                                             @ApiParam(value = "Authorise Consent Request", required = true)
                                                             @Valid
-                                                            @RequestBody AuthorisePaymentConsentRequest request,
-                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                            @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject Domestic Payment Consent")
@@ -123,8 +120,7 @@ public interface DomesticPaymentConsentApi {
     ResponseEntity<DomesticPaymentConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
                                                          @ApiParam(value = "Reject Consent Request", required = true)
                                                          @Valid
-                                                         @RequestBody RejectConsentRequest request,
-                                                         @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                         @RequestBody RejectConsentRequest request);
 
 
 
@@ -146,7 +142,6 @@ public interface DomesticPaymentConsentApi {
     ResponseEntity<DomesticPaymentConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
                                                           @ApiParam(value = "Consume Consent Request", required = true)
                                                           @Valid
-                                                          @RequestBody ConsumePaymentConsentRequest request,
-                                                          @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                          @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
@@ -70,8 +70,8 @@ public class DomesticPaymentConsentApiController implements DomesticPaymentConse
     }
 
     @Override
-    public ResponseEntity<DomesticPaymentConsent> createConsent(CreateDomesticPaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<DomesticPaymentConsent> createConsent(CreateDomesticPaymentConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final DomesticPaymentConsentEntity domesticPaymentConsent = new DomesticPaymentConsentEntity();
         domesticPaymentConsent.setRequestVersion(obVersion);
         domesticPaymentConsent.setApiClientId(request.getApiClientId());
@@ -93,23 +93,24 @@ public class DomesticPaymentConsentApiController implements DomesticPaymentConse
     }
 
     @Override
-    public ResponseEntity<DomesticPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<DomesticPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<DomesticPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<DomesticPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<DomesticPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<DomesticPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private DomesticPaymentConsent convertEntityToDto(DomesticPaymentConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApi.java
@@ -58,11 +58,9 @@ public interface DomesticScheduledPaymentConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<DomesticScheduledPaymentConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateDomesticScheduledPaymentConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<DomesticScheduledPaymentConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                                  @Valid
+                                                                  @RequestBody CreateDomesticScheduledPaymentConsentRequest request);
 
 
     @ApiOperation(value = "Get Domestic Scheduled Payment Consent")
@@ -80,7 +78,7 @@ public interface DomesticScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<DomesticScheduledPaymentConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-                                                      @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                               @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise Domestic Scheduled Payment Consent")
@@ -99,10 +97,9 @@ public interface DomesticScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticScheduledPaymentConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-                                                            @ApiParam(value = "Authorise Consent Request", required = true)
-                                                            @Valid
-                                                            @RequestBody AuthorisePaymentConsentRequest request,
-                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                     @ApiParam(value = "Authorise Consent Request", required = true)
+                                                                     @Valid
+                                                                     @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject Domestic Scheduled Payment Consent")
@@ -121,10 +118,9 @@ public interface DomesticScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticScheduledPaymentConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-                                                         @ApiParam(value = "Reject Consent Request", required = true)
-                                                         @Valid
-                                                         @RequestBody RejectConsentRequest request,
-                                                         @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                  @ApiParam(value = "Reject Consent Request", required = true)
+                                                                  @Valid
+                                                                  @RequestBody RejectConsentRequest request);
 
 
 
@@ -144,9 +140,8 @@ public interface DomesticScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticScheduledPaymentConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                          @ApiParam(value = "Consume Consent Request", required = true)
-                                                          @Valid
-                                                          @RequestBody ConsumePaymentConsentRequest request,
-                                                          @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                   @ApiParam(value = "Consume Consent Request", required = true)
+                                                                   @Valid
+                                                                   @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApiController.java
@@ -70,10 +70,9 @@ public class DomesticScheduledPaymentConsentApiController implements DomesticSch
     }
 
     @Override
-    public ResponseEntity<DomesticScheduledPaymentConsent> createConsent(CreateDomesticScheduledPaymentConsentRequest request,
-                                                                         String apiClientId) {
+    public ResponseEntity<DomesticScheduledPaymentConsent> createConsent(CreateDomesticScheduledPaymentConsentRequest request) {
 
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+        logger.info("Attempting to createConsent: {}", request);
         final DomesticScheduledPaymentConsentEntity domesticScheduledPaymentConsent = new DomesticScheduledPaymentConsentEntity();
         domesticScheduledPaymentConsent.setRequestVersion(obVersion);
         domesticScheduledPaymentConsent.setApiClientId(request.getApiClientId());
@@ -96,25 +95,25 @@ public class DomesticScheduledPaymentConsentApiController implements DomesticSch
 
     @Override
     public ResponseEntity<DomesticScheduledPaymentConsent> authoriseConsent(String consentId,
-                                                                            AuthorisePaymentConsentRequest request,
-                                                                            String apiClientId) {
+                                                                            AuthorisePaymentConsentRequest request) {
 
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<DomesticScheduledPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<DomesticScheduledPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<DomesticScheduledPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<DomesticScheduledPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private DomesticScheduledPaymentConsent convertEntityToDto(DomesticScheduledPaymentConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApi.java
@@ -58,11 +58,9 @@ public interface DomesticStandingOrderConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<DomesticStandingOrderConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateDomesticStandingOrderConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<DomesticStandingOrderConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                               @Valid
+                                                               @RequestBody CreateDomesticStandingOrderConsentRequest request);
 
 
     @ApiOperation(value = "Get Domestic Standing Order Consent")
@@ -80,7 +78,7 @@ public interface DomesticStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<DomesticStandingOrderConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-                                                      @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise Domestic Standing Order Consent")
@@ -99,10 +97,9 @@ public interface DomesticStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticStandingOrderConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-                                                            @ApiParam(value = "Authorise Consent Request", required = true)
-                                                            @Valid
-                                                            @RequestBody AuthorisePaymentConsentRequest request,
-                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                  @ApiParam(value = "Authorise Consent Request", required = true)
+                                                                  @Valid
+                                                                  @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject Domestic Standing Order Consent")
@@ -121,10 +118,9 @@ public interface DomesticStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticStandingOrderConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-                                                         @ApiParam(value = "Reject Consent Request", required = true)
-                                                         @Valid
-                                                         @RequestBody RejectConsentRequest request,
-                                                         @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                               @ApiParam(value = "Reject Consent Request", required = true)
+                                                               @Valid
+                                                               @RequestBody RejectConsentRequest request);
 
 
 
@@ -144,9 +140,8 @@ public interface DomesticStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticStandingOrderConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                          @ApiParam(value = "Consume Consent Request", required = true)
-                                                          @Valid
-                                                          @RequestBody ConsumePaymentConsentRequest request,
-                                                          @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                @ApiParam(value = "Consume Consent Request", required = true)
+                                                                @Valid
+                                                                @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApiController.java
@@ -64,16 +64,15 @@ public class DomesticStandingOrderConsentApiController implements DomesticStandi
     public DomesticStandingOrderConsentApiController(DomesticStandingOrderConsentService consentService,
                                                      Supplier<DateTime> idempotencyKeyExpirationSupplier,
                                                      OBVersion obVersion) {
+
         this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
         this.idempotencyKeyExpirationSupplier = Objects.requireNonNull(idempotencyKeyExpirationSupplier, "idempotencyKeyExpirationSupplier must be provided");
         this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
     }
 
     @Override
-    public ResponseEntity<DomesticStandingOrderConsent> createConsent(CreateDomesticStandingOrderConsentRequest request,
-                                                                      String apiClientId) {
-
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<DomesticStandingOrderConsent> createConsent(CreateDomesticStandingOrderConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final DomesticStandingOrderConsentEntity domesticStandingOrderConsent = new DomesticStandingOrderConsentEntity();
         domesticStandingOrderConsent.setRequestVersion(obVersion);
         domesticStandingOrderConsent.setApiClientId(request.getApiClientId());
@@ -95,26 +94,23 @@ public class DomesticStandingOrderConsentApiController implements DomesticStandi
     }
 
     @Override
-    public ResponseEntity<DomesticStandingOrderConsent> authoriseConsent(String consentId,
-                                                                            AuthorisePaymentConsentRequest request,
-                                                                            String apiClientId) {
-
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<DomesticStandingOrderConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, request.getApiClientId(),
+                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<DomesticStandingOrderConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<DomesticStandingOrderConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<DomesticStandingOrderConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<DomesticStandingOrderConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private DomesticStandingOrderConsent convertEntityToDto(DomesticStandingOrderConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApi.java
@@ -59,11 +59,9 @@ public interface FilePaymentConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<FilePaymentConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateFilePaymentConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<FilePaymentConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                     @Valid
+                                                     @RequestBody CreateFilePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Get File Payment Consent")
@@ -103,8 +101,7 @@ public interface FilePaymentConsentApi {
     ResponseEntity<FilePaymentConsent> uploadFile(@PathVariable(value = "consentId") String consentId,
                                                   @ApiParam(value = "File Upload Request", required = true)
                                                   @Valid
-                                                  @RequestBody FileUploadRequest request,
-                                                  @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                  @RequestBody FileUploadRequest request);
 
 
     @ApiOperation(value = "Authorise File Payment Consent")
@@ -125,8 +122,7 @@ public interface FilePaymentConsentApi {
     ResponseEntity<FilePaymentConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
                                                         @ApiParam(value = "Authorise Consent Request", required = true)
                                                         @Valid
-                                                        @RequestBody AuthorisePaymentConsentRequest request,
-                                                        @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                        @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject File Payment Consent")
@@ -147,8 +143,7 @@ public interface FilePaymentConsentApi {
     ResponseEntity<FilePaymentConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
                                                      @ApiParam(value = "Reject Consent Request", required = true)
                                                      @Valid
-                                                     @RequestBody RejectConsentRequest request,
-                                                     @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                     @RequestBody RejectConsentRequest request);
 
 
 
@@ -170,7 +165,6 @@ public interface FilePaymentConsentApi {
     ResponseEntity<FilePaymentConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
                                                       @ApiParam(value = "Consume Consent Request", required = true)
                                                       @Valid
-                                                      @RequestBody ConsumePaymentConsentRequest request,
-                                                      @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                      @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApiController.java
@@ -74,8 +74,8 @@ public class FilePaymentConsentApiController implements FilePaymentConsentApi {
     }
 
     @Override
-    public ResponseEntity<FilePaymentConsent> createConsent(CreateFilePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<FilePaymentConsent> createConsent(CreateFilePaymentConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final FilePaymentConsentEntity domesticPaymentConsent = new FilePaymentConsentEntity();
         domesticPaymentConsent.setRequestVersion(obVersion);
         domesticPaymentConsent.setApiClientId(request.getApiClientId());
@@ -91,12 +91,12 @@ public class FilePaymentConsentApiController implements FilePaymentConsentApi {
     }
 
     @Override
-    public ResponseEntity<FilePaymentConsent> uploadFile(String consentId, FileUploadRequest request, String apiClientId) {
-        logger.info("Attempting to uploadFile - consentId: {}, apiClientId: {},  fileUploadIdempotencyKey:", consentId, request.getFileUploadIdempotencyKey(), apiClientId);
+    public ResponseEntity<FilePaymentConsent> uploadFile(String consentId, FileUploadRequest request) {
+        logger.info("Attempting to uploadFile - consentId: {},  fileUploadIdempotencyKey: {}", consentId, request.getFileUploadIdempotencyKey());
         final FileUploadArgs fileUploadArgs = new FileUploadArgs();
         fileUploadArgs.setFileContents(request.getFileContents());
         fileUploadArgs.setConsentId(consentId);
-        fileUploadArgs.setApiClientId(apiClientId);
+        fileUploadArgs.setApiClientId(request.getApiClientId());
         fileUploadArgs.setFileUploadIdempotencyKey(request.getFileUploadIdempotencyKey());
         return ResponseEntity.ok(convertEntityToDto(consentService.uploadFile(fileUploadArgs)));
     }
@@ -108,24 +108,24 @@ public class FilePaymentConsentApiController implements FilePaymentConsentApi {
     }
 
     @Override
-    public ResponseEntity<FilePaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
+    public ResponseEntity<FilePaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
         final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
-                apiClientId, request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
 
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<FilePaymentConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<FilePaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<FilePaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<FilePaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private FilePaymentConsent convertEntityToDto(FilePaymentConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApi.java
@@ -58,11 +58,9 @@ public interface InternationalPaymentConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<InternationalPaymentConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateInternationalPaymentConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<InternationalPaymentConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                              @Valid
+                                                              @RequestBody CreateInternationalPaymentConsentRequest request);
 
 
     @ApiOperation(value = "Get International Payment Consent")
@@ -101,8 +99,7 @@ public interface InternationalPaymentConsentApi {
     ResponseEntity<InternationalPaymentConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
                                                                  @ApiParam(value = "Authorise Consent Request", required = true)
                                                                  @Valid
-                                                                 @RequestBody AuthorisePaymentConsentRequest request,
-                                                                 @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                 @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject International Payment Consent")
@@ -123,8 +120,7 @@ public interface InternationalPaymentConsentApi {
     ResponseEntity<InternationalPaymentConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
                                                               @ApiParam(value = "Reject Consent Request", required = true)
                                                               @Valid
-                                                              @RequestBody RejectConsentRequest request,
-                                                              @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                              @RequestBody RejectConsentRequest request);
 
 
 
@@ -146,7 +142,6 @@ public interface InternationalPaymentConsentApi {
     ResponseEntity<InternationalPaymentConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
                                                                @ApiParam(value = "Consume Consent Request", required = true)
                                                                @Valid
-                                                               @RequestBody ConsumePaymentConsentRequest request,
-                                                               @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                               @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiController.java
@@ -70,8 +70,8 @@ public class InternationalPaymentConsentApiController implements InternationalPa
     }
 
     @Override
-    public ResponseEntity<InternationalPaymentConsent> createConsent(CreateInternationalPaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<InternationalPaymentConsent> createConsent(CreateInternationalPaymentConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final InternationalPaymentConsentEntity internationalPaymentConsent = new InternationalPaymentConsentEntity();
         internationalPaymentConsent.setRequestVersion(obVersion);
         internationalPaymentConsent.setApiClientId(request.getApiClientId());
@@ -94,23 +94,23 @@ public class InternationalPaymentConsentApiController implements InternationalPa
     }
 
     @Override
-    public ResponseEntity<InternationalPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<InternationalPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<InternationalPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<InternationalPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<InternationalPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<InternationalPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private InternationalPaymentConsent convertEntityToDto(InternationalPaymentConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApi.java
@@ -58,11 +58,9 @@ public interface InternationalScheduledPaymentConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<InternationalScheduledPaymentConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateInternationalScheduledPaymentConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<InternationalScheduledPaymentConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                                       @Valid
+                                                                       @RequestBody CreateInternationalScheduledPaymentConsentRequest request);
 
 
     @ApiOperation(value = "Get International Scheduled Payment Consent")
@@ -80,7 +78,7 @@ public interface InternationalScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<InternationalScheduledPaymentConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-                                                           @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                    @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise International Scheduled Payment Consent")
@@ -99,10 +97,9 @@ public interface InternationalScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalScheduledPaymentConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-                                                                 @ApiParam(value = "Authorise Consent Request", required = true)
-                                                                 @Valid
-                                                                 @RequestBody AuthorisePaymentConsentRequest request,
-                                                                 @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                          @ApiParam(value = "Authorise Consent Request", required = true)
+                                                                          @Valid
+                                                                          @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject International Scheduled Payment Consent")
@@ -121,10 +118,9 @@ public interface InternationalScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalScheduledPaymentConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-                                                              @ApiParam(value = "Reject Consent Request", required = true)
-                                                              @Valid
-                                                              @RequestBody RejectConsentRequest request,
-                                                              @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                       @ApiParam(value = "Reject Consent Request", required = true)
+                                                                       @Valid
+                                                                       @RequestBody RejectConsentRequest request);
 
 
 
@@ -144,9 +140,8 @@ public interface InternationalScheduledPaymentConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalScheduledPaymentConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                               @ApiParam(value = "Consume Consent Request", required = true)
-                                                               @Valid
-                                                               @RequestBody ConsumePaymentConsentRequest request,
-                                                               @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                        @ApiParam(value = "Consume Consent Request", required = true)
+                                                                        @Valid
+                                                                        @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiController.java
@@ -70,8 +70,8 @@ public class InternationalScheduledPaymentConsentApiController implements Intern
     }
 
     @Override
-    public ResponseEntity<InternationalScheduledPaymentConsent> createConsent(CreateInternationalScheduledPaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<InternationalScheduledPaymentConsent> createConsent(CreateInternationalScheduledPaymentConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final InternationalScheduledPaymentConsentEntity internationalPaymentConsent = new InternationalScheduledPaymentConsentEntity();
         internationalPaymentConsent.setRequestVersion(obVersion);
         internationalPaymentConsent.setApiClientId(request.getApiClientId());
@@ -94,23 +94,23 @@ public class InternationalScheduledPaymentConsentApiController implements Intern
     }
 
     @Override
-    public ResponseEntity<InternationalScheduledPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<InternationalScheduledPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<InternationalScheduledPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<InternationalScheduledPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<InternationalScheduledPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<InternationalScheduledPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {},", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private InternationalScheduledPaymentConsent convertEntityToDto(InternationalScheduledPaymentConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApi.java
@@ -58,11 +58,9 @@ public interface InternationalStandingOrderConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<InternationalStandingOrderConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateInternationalStandingOrderConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<InternationalStandingOrderConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                                    @Valid
+                                                                    @RequestBody CreateInternationalStandingOrderConsentRequest request);
 
 
     @ApiOperation(value = "Get International Standing Order Consent")
@@ -80,7 +78,7 @@ public interface InternationalStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<InternationalStandingOrderConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-                                                           @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                 @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise International Standing Order Consent")
@@ -99,10 +97,9 @@ public interface InternationalStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalStandingOrderConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-                                                                 @ApiParam(value = "Authorise Consent Request", required = true)
-                                                                 @Valid
-                                                                 @RequestBody AuthorisePaymentConsentRequest request,
-                                                                 @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                       @ApiParam(value = "Authorise Consent Request", required = true)
+                                                                       @Valid
+                                                                       @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject International Standing Order Consent")
@@ -121,10 +118,9 @@ public interface InternationalStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalStandingOrderConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-                                                              @ApiParam(value = "Reject Consent Request", required = true)
-                                                              @Valid
-                                                              @RequestBody RejectConsentRequest request,
-                                                              @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                    @ApiParam(value = "Reject Consent Request", required = true)
+                                                                    @Valid
+                                                                    @RequestBody RejectConsentRequest request);
 
 
 
@@ -144,9 +140,8 @@ public interface InternationalStandingOrderConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<InternationalStandingOrderConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                               @ApiParam(value = "Consume Consent Request", required = true)
-                                                               @Valid
-                                                               @RequestBody ConsumePaymentConsentRequest request,
-                                                               @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                                     @ApiParam(value = "Consume Consent Request", required = true)
+                                                                     @Valid
+                                                                     @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
@@ -70,8 +70,8 @@ public class InternationalStandingOrderConsentApiController implements Internati
     }
 
     @Override
-    public ResponseEntity<InternationalStandingOrderConsent> createConsent(CreateInternationalStandingOrderConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<InternationalStandingOrderConsent> createConsent(CreateInternationalStandingOrderConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final InternationalStandingOrderConsentEntity internationalPaymentConsent = new InternationalStandingOrderConsentEntity();
         internationalPaymentConsent.setRequestVersion(obVersion);
         internationalPaymentConsent.setApiClientId(request.getApiClientId());
@@ -93,23 +93,23 @@ public class InternationalStandingOrderConsentApiController implements Internati
     }
 
     @Override
-    public ResponseEntity<InternationalStandingOrderConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<InternationalStandingOrderConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<InternationalStandingOrderConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<InternationalStandingOrderConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<InternationalStandingOrderConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<InternationalStandingOrderConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private InternationalStandingOrderConsent convertEntityToDto(InternationalStandingOrderConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
@@ -58,11 +58,9 @@ public interface DomesticVRPConsentApi {
             consumes = {"application/json; charset=utf-8"},
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
-    ResponseEntity<DomesticVRPConsent> createConsent(
-            @ApiParam(value = "Create Consent Request", required = true)
-            @Valid
-            @RequestBody CreateDomesticVRPConsentRequest request,
-            @RequestHeader(value = "x-api-client-id") String apiClientId);
+    ResponseEntity<DomesticVRPConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                     @Valid
+                                                     @RequestBody CreateDomesticVRPConsentRequest request);
 
 
     @ApiOperation(value = "Get Domestic VRP Consent")
@@ -80,7 +78,7 @@ public interface DomesticVRPConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<DomesticVRPConsent> getConsent(@PathVariable(value = "consentId") String consentId,
-                                                      @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                  @RequestHeader(value = "x-api-client-id") String apiClientId);
 
 
     @ApiOperation(value = "Authorise Domestic VRP Consent")
@@ -99,10 +97,9 @@ public interface DomesticVRPConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticVRPConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
-                                                            @ApiParam(value = "Authorise Consent Request", required = true)
-                                                            @Valid
-                                                            @RequestBody AuthorisePaymentConsentRequest request,
-                                                            @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                        @ApiParam(value = "Authorise Consent Request", required = true)
+                                                        @Valid
+                                                        @RequestBody AuthorisePaymentConsentRequest request);
 
 
     @ApiOperation(value = "Reject Domestic VRP Consent")
@@ -121,10 +118,9 @@ public interface DomesticVRPConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticVRPConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
-                                                         @ApiParam(value = "Reject Consent Request", required = true)
-                                                         @Valid
-                                                         @RequestBody RejectConsentRequest request,
-                                                         @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                     @ApiParam(value = "Reject Consent Request", required = true)
+                                                     @Valid
+                                                     @RequestBody RejectConsentRequest request);
 
 
 
@@ -144,9 +140,8 @@ public interface DomesticVRPConsentApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<DomesticVRPConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                          @ApiParam(value = "Consume Consent Request", required = true)
-                                                          @Valid
-                                                          @RequestBody ConsumePaymentConsentRequest request,
-                                                          @RequestHeader(value = "x-api-client-id") String apiClientId);
+                                                      @ApiParam(value = "Consume Consent Request", required = true)
+                                                      @Valid
+                                                      @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
@@ -70,8 +70,8 @@ public class DomesticVRPConsentApiController implements DomesticVRPConsentApi {
     }
 
     @Override
-    public ResponseEntity<DomesticVRPConsent> createConsent(CreateDomesticVRPConsentRequest request, String apiClientId) {
-        logger.info("Attempting to createConsent: {}, for apiClientId: {}", request, apiClientId);
+    public ResponseEntity<DomesticVRPConsent> createConsent(CreateDomesticVRPConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
         final DomesticVRPConsentEntity domesticPaymentConsent = new DomesticVRPConsentEntity();
         domesticPaymentConsent.setRequestVersion(obVersion);
         domesticPaymentConsent.setApiClientId(request.getApiClientId());
@@ -93,23 +93,23 @@ public class DomesticVRPConsentApiController implements DomesticVRPConsentApi {
     }
 
     @Override
-    public ResponseEntity<DomesticVRPConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId, apiClientId,
-                                                                                                                                request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+    public ResponseEntity<DomesticVRPConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
         return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
     }
 
     @Override
-    public ResponseEntity<DomesticVRPConsent> rejectConsent(String consentId, RejectConsentRequest request, String apiClientId) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, apiClientId, request.getResourceOwnerId())));
+    public ResponseEntity<DomesticVRPConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
     @Override
-    public ResponseEntity<DomesticVRPConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request, String apiClientId) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}, apiClientId: {}", consentId, request, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, apiClientId)));
+    public ResponseEntity<DomesticVRPConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private DomesticVRPConsent convertEntityToDto(DomesticVRPConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseAuthoriseConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseAuthoriseConsentRequest.java
@@ -31,7 +31,6 @@ public abstract class BaseAuthoriseConsentRequest {
     @NotNull
     private String resourceOwnerId;
 
-
     public BaseAuthoriseConsentRequest() {
     }
 
@@ -57,5 +56,14 @@ public abstract class BaseAuthoriseConsentRequest {
 
     public void setApiClientId(String apiClientId) {
         this.apiClientId = apiClientId;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseAuthoriseConsentRequest{" +
+                "apiClientId='" + apiClientId + '\'' +
+                ", consentId='" + consentId + '\'' +
+                ", resourceOwnerId='" + resourceOwnerId + '\'' +
+                '}';
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseCreateConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/BaseCreateConsentRequest.java
@@ -44,4 +44,12 @@ public abstract class BaseCreateConsentRequest<T> {
     public void setConsentRequest(T consentRequest) {
         this.consentRequest = consentRequest;
     }
+
+    @Override
+    public String toString() {
+        return "BaseCreateConsentRequest{" +
+                "apiClientId='" + apiClientId + '\'' +
+                ", consentRequest=" + consentRequest +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/RejectConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/RejectConsentRequest.java
@@ -57,5 +57,14 @@ public class RejectConsentRequest {
     public void setApiClientId(String apiClientId) {
         this.apiClientId = apiClientId;
     }
+
+    @Override
+    public String toString() {
+        return "RejectConsentRequest{" +
+                "apiClientId='" + apiClientId + '\'' +
+                ", consentId='" + consentId + '\'' +
+                ", resourceOwnerId='" + resourceOwnerId + '\'' +
+                '}';
+    }
 }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/account/v3_1_10/AccountAccessConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/account/v3_1_10/AccountAccessConsent.java
@@ -39,4 +39,18 @@ public class AccountAccessConsent extends BaseConsent<OBReadConsent1> {
         return authorisedAccountIds;
     }
 
+    @Override
+    public String toString() {
+        return "AccountAccessConsent{" +
+                "authorisedAccountIds=" + authorisedAccountIds +
+                ", id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/account/v3_1_10/AuthoriseAccountAccessConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/account/v3_1_10/AuthoriseAccountAccessConsentRequest.java
@@ -38,4 +38,14 @@ public class AuthoriseAccountAccessConsentRequest extends BaseAuthoriseConsentRe
     public void setAuthorisedAccountIds(List<String> authorisedAccountIds) {
         this.authorisedAccountIds = authorisedAccountIds;
     }
+
+    @Override
+    public String toString() {
+        return "AuthoriseAccountAccessConsentRequest{" +
+                "authorisedAccountIds=" + authorisedAccountIds +
+                ", consentId='" + getConsentId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/AuthorisePaymentConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/AuthorisePaymentConsentRequest.java
@@ -40,4 +40,13 @@ public class AuthorisePaymentConsentRequest extends BaseAuthoriseConsentRequest 
         this.authorisedDebtorAccountId = authorisedDebtorAccountId;
     }
 
+    @Override
+    public String toString() {
+        return "AuthorisePaymentConsentRequest{" +
+                "authorisedDebtorAccountId='" + authorisedDebtorAccountId + '\'' +
+                ", consentId='" + getConsentId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BaseCreateInternationalPaymentConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BaseCreateInternationalPaymentConsentRequest.java
@@ -28,4 +28,15 @@ public class BaseCreateInternationalPaymentConsentRequest<T> extends BaseCreateP
     public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
         this.exchangeRateInformation = exchangeRateInformation;
     }
+
+    @Override
+    public String toString() {
+        return "BaseCreateInternationalPaymentConsentRequest{" +
+                "exchangeRateInformation=" + exchangeRateInformation +
+                ", idempotencyKey='" + getIdempotencyKey() + '\'' +
+                ", charges=" + getCharges() +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", consentRequest=" + getConsentRequest() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BaseCreatePaymentConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BaseCreatePaymentConsentRequest.java
@@ -44,4 +44,14 @@ public class BaseCreatePaymentConsentRequest<T> extends BaseCreateConsentRequest
     public void setCharges(List<FRCharge> charges) {
         this.charges = charges;
     }
+
+    @Override
+    public String toString() {
+        return "BaseCreatePaymentConsentRequest{" +
+                "idempotencyKey='" + idempotencyKey + '\'' +
+                ", charges=" + charges +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", consentRequest=" + getConsentRequest() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsent.java
@@ -68,4 +68,22 @@ public abstract class BasePaymentConsent<T> extends BaseConsent<T> {
     public void setCharges(List<FRCharge> charges) {
         this.charges = charges;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+                "idempotencyKey='" + idempotencyKey + '\'' +
+                ", idempotencyKeyExpiration=" + idempotencyKeyExpiration +
+                ", authorisedDebtorAccountId='" + authorisedDebtorAccountId + '\'' +
+                ", charges=" + charges +
+                ", id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsentWithExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/BasePaymentConsentWithExchangeRateInformation.java
@@ -31,4 +31,23 @@ public abstract class BasePaymentConsentWithExchangeRateInformation<T> extends B
     public void setExchangeRateInformation(FRExchangeRateInformation exchangeRateInformation) {
         this.exchangeRateInformation = exchangeRateInformation;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+                "exchangeRateInformation=" + exchangeRateInformation +
+                ", idempotencyKey='" + getIdempotencyKey() + '\'' +
+                ", idempotencyKeyExpiration=" + getIdempotencyKeyExpiration() +
+                ", authorisedDebtorAccountId='" + getAuthorisedDebtorAccountId() + '\'' +
+                ", charges=" + getCharges() +
+                ", id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/ConsumePaymentConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/ConsumePaymentConsentRequest.java
@@ -46,4 +46,12 @@ public class ConsumePaymentConsentRequest {
     public void setApiClientId(String apiClientId) {
         this.apiClientId = apiClientId;
     }
+
+    @Override
+    public String toString() {
+        return "ConsumePaymentConsentRequest{" +
+                "apiClientId='" + apiClientId + '\'' +
+                ", consentId='" + consentId + '\'' +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/file/v3_1_10/FilePaymentConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/file/v3_1_10/FilePaymentConsent.java
@@ -45,4 +45,23 @@ public class FilePaymentConsent extends BasePaymentConsent<FRWriteFileConsent> {
     public void setFileUploadIdempotencyKey(String fileUploadIdempotencyKey) {
         this.fileUploadIdempotencyKey = fileUploadIdempotencyKey;
     }
+
+    @Override
+    public String toString() {
+        return "FilePaymentConsent{" +
+                "fileUploadIdempotencyKey='" + fileUploadIdempotencyKey + '\'' +
+                ", idempotencyKey='" + getIdempotencyKey() + '\'' +
+                ", idempotencyKeyExpiration=" + getIdempotencyKeyExpiration() +
+                ", authorisedDebtorAccountId='" + getAuthorisedDebtorAccountId() + '\'' +
+                ", charges=" + getCharges() +
+                ", id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/file/v3_1_10/FileUploadRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/datamodel/payment/file/v3_1_10/FileUploadRequest.java
@@ -66,4 +66,12 @@ public class FileUploadRequest {
         this.fileUploadIdempotencyKey = fileUploadIdempotencyKey;
     }
 
+    @Override
+    public String toString() {
+        return "FileUploadRequest{" +
+                "consentId='" + consentId + '\'' +
+                ", apiClientId='" + apiClientId + '\'' +
+                ", fileUploadIdempotencyKey='" + fileUploadIdempotencyKey + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
x-api-client-id header is only needed for GET requests, for POSTs the value is in the request body.

Also adding toString methods to DTOs so that we can log the information in controller requests.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1032