### PR TITLE
1040: prepare versions to build release 1.0.3

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 1.0.2
-appVersion: 1.0.2
+version: 1.0.3
+appVersion: 1.0.3

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.5-SNAPSHOT</uk.bom.version>
+        <uk.bom.version>1.0.5</uk.bom.version>
         <gson.version>2.10.1</gson.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>


### PR DESCRIPTION
- Updated helm charts version to 1.0.3
- Bumped common version 1.0.5

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1040