### PR TITLE
1019: Supporting Deleting (Revoking) an Account Access Consent

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
@@ -122,4 +122,22 @@ public interface AccountAccessConsentApi {
                                                        @Valid
                                                        @RequestBody RejectConsentRequest request);
 
+
+    @ApiOperation(value = "Delete Account Access Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Delete successful"),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/account-access-consents/{consentId}",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.DELETE)
+    ResponseEntity<Void> deleteConsent(@PathVariable(value = "consentId") String consentId,
+                                       @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
@@ -89,6 +89,13 @@ public class AccountAccessConsentApiController implements AccountAccessConsentAp
         return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
+    @Override
+    public ResponseEntity<Void> deleteConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to deleteConsent - id: {}, apiClientId: {}", consentId, apiClientId);
+        consentService.deleteConsent(consentId, apiClientId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     private AccountAccessConsent convertEntityToDto(AccountAccessConsentEntity entity) {
         final AccountAccessConsent dto = new AccountAccessConsent();
         dto.setApiClientId(entity.getApiClientId());

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/AccountAccessConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/AccountAccessConsentStoreClient.java
@@ -34,4 +34,6 @@ public interface AccountAccessConsentStoreClient {
 
     AccountAccessConsent rejectConsent(RejectConsentRequest rejectAccountAccessConsentRequest) throws ConsentStoreClientException;
 
+    void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/RestAccountAccessConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/RestAccountAccessConsentStoreClient.java
@@ -79,4 +79,11 @@ public class RestAccountAccessConsentStoreClient extends BaseRestConsentStoreCli
         final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
         return doRestCall(url, HttpMethod.POST, requestEntity, AccountAccessConsent.class);
     }
+
+    @Override
+    public void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        doRestCall(url, HttpMethod.DELETE, requestEntity, Void.class);
+    }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/AccountAccessConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/account/v3_1_10/AccountAccessConsentStoreClientTest.java
@@ -121,6 +121,13 @@ public class AccountAccessConsentStoreClientTest {
         assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
     }
 
+    @Test
+    void testDeleteConsent() {
+        final CreateAccountAccessConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final AccountAccessConsent consent = apiClient.createConsent(createConsentRequest);
+        apiClient.deleteConsent(consent.getId(), consent.getApiClientId());
+    }
+
     private static CreateAccountAccessConsentRequest buildCreateConsentRequest() {
         final CreateAccountAccessConsentRequest createConsentRequest = new CreateAccountAccessConsentRequest();
         createConsentRequest.setApiClientId("test-client-1");
@@ -130,9 +137,9 @@ public class AccountAccessConsentStoreClientTest {
         return createConsentRequest;
     }
 
-    private static AuthoriseAccountAccessConsentRequest buildAuthoriseConsentRequest(AccountAccessConsent consent, String resourceOwnerId, List<String> authoirsedAccounts) {
+    private static AuthoriseAccountAccessConsentRequest buildAuthoriseConsentRequest(AccountAccessConsent consent, String resourceOwnerId, List<String> authorisedAccounts) {
         final AuthoriseAccountAccessConsentRequest authRequest = new AuthoriseAccountAccessConsentRequest();
-        authRequest.setAuthorisedAccountIds(authoirsedAccounts);
+        authRequest.setAuthorisedAccountIds(authorisedAccounts);
         authRequest.setConsentId(consent.getId());
         authRequest.setResourceOwnerId(resourceOwnerId);
         authRequest.setApiClientId(consent.getApiClientId());

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/BaseConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/BaseConsentEntity.java
@@ -72,6 +72,13 @@ public class BaseConsentEntity<T> {
     private String resourceOwnerId;
 
     /**
+     * Flag to support soft deletes
+     *
+     * If a consent has been deleted then it should not be returned via the API
+     */
+    private boolean deleted;
+
+    /**
      * Time at which the Consent was persisted
      */
     @CreatedDate
@@ -148,6 +155,14 @@ public class BaseConsentEntity<T> {
         return entityVersion;
     }
 
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
     @Override
     public String toString() {
         return "BaseConsentEntity{" +
@@ -158,6 +173,7 @@ public class BaseConsentEntity<T> {
                 ", status='" + status + '\'' +
                 ", apiClientId='" + apiClientId + '\'' +
                 ", resourceOwnerId='" + resourceOwnerId + '\'' +
+                ", deleted=" + deleted +
                 ", creationDateTime=" + creationDateTime +
                 ", statusUpdatedDateTime=" + statusUpdatedDateTime +
                 '}';

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/BaseConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/BaseConsentService.java
@@ -93,6 +93,9 @@ public abstract class BaseConsentService<T extends BaseConsentEntity<?>, A exten
         if (!Objects.equals(consent.getApiClientId(), apiClientId)) {
             throw new ConsentStoreException(ErrorType.INVALID_PERMISSIONS, consentId);
         }
+        if (consent.isDeleted()) {
+            throw new ConsentStoreException(ErrorType.NOT_FOUND, consentId);
+        }
         return consent;
     }
 
@@ -130,10 +133,10 @@ public abstract class BaseConsentService<T extends BaseConsentEntity<?>, A exten
     }
 
     @Override
-    public T revokeConsent(String consentId, String apiClientId) {
+    public void deleteConsent(String consentId, String apiClientId) {
         final T consent = getConsent(consentId, apiClientId);
-        validateStateTransition(consent, revokedConsentStatus);
         consent.setStatus(revokedConsentStatus);
-        return repo.save(consent);
+        consent.setDeleted(true);
+        repo.save(consent);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentService.java
@@ -38,6 +38,6 @@ public interface ConsentService<T extends BaseConsentEntity, A extends Authorise
 
     T rejectConsent(String consentId, String apiClientId, String resourceOwnerId);
 
-    T revokeConsent(String consentId, String apiClientId);
+    void deleteConsent(String consentId, String apiClientId);
 
 }


### PR DESCRIPTION
- Deleted flag added to BaseConsentEntity to support soft deletes
- Get consent will throw NOT_FOUND error if a consent is found with the deleted flag set
- Adding deleteConsent method to AccountAccessConsentApi + Controller + Rest client

https://github.com/SecureApiGateway/SecureApiGateway/issues/1019