### PR TITLE
1012: Enabling Domestic Payment Consents to use the Consent Store

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -79,7 +79,7 @@ consent:
   store:
     enabled:
       # Controls which intentTypes will use the new Consent Store (format: comma separated list)
-      intentTypes:
+      intentTypes: PAYMENT_DOMESTIC_CONSENT
 
 spring:
   data:


### PR DESCRIPTION
Turning on the RCS Consent Store for Domestic Payments

Required as part of RS PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/pull/200

https://github.com/SecureApiGateway/SecureApiGateway/issues/1012