### PR TITLE
1047: Support Re-authentication for long-lived consents

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApi.java
@@ -134,7 +134,6 @@ public interface AccountAccessConsentApi {
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
     })
     @RequestMapping(value = "/account-access-consents/{consentId}",
-            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.DELETE)
     ResponseEntity<Void> deleteConsent(@PathVariable(value = "consentId") String consentId,
                                        @RequestHeader(value = "x-api-client-id") String apiClientId);

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 
@@ -121,27 +120,5 @@ public interface DomesticVRPConsentApi {
                                                      @ApiParam(value = "Reject Consent Request", required = true)
                                                      @Valid
                                                      @RequestBody RejectConsentRequest request);
-
-
-
-    @ApiOperation(value = "Consume Domestic VRP Consent")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "DomesticVRPConsent object representing the consent created",
-                         response = DomesticVRPConsent.class),
-            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
-            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
-            @ApiResponse(code = 404, message = "Not found"),
-            @ApiResponse(code = 405, message = "Method Not Allowed"),
-            @ApiResponse(code = 406, message = "Not Acceptable"),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
-    })
-    @RequestMapping(value = "/domestic-vrp-consents/{consentId}/consume",
-            consumes = {"application/json; charset=utf-8"},
-            produces = {"application/json; charset=utf-8"},
-            method = RequestMethod.POST)
-    ResponseEntity<DomesticVRPConsent> consumeConsent(@PathVariable(value = "consentId") String consentId,
-                                                      @ApiParam(value = "Consume Consent Request", required = true)
-                                                      @Valid
-                                                      @RequestBody ConsumePaymentConsentRequest request);
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
@@ -28,7 +28,6 @@ import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
@@ -104,12 +103,6 @@ public class DomesticVRPConsentApiController implements DomesticVRPConsentApi {
     public ResponseEntity<DomesticVRPConsent> rejectConsent(String consentId, RejectConsentRequest request) {
         logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
         return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
-    }
-
-    @Override
-    public ResponseEntity<DomesticVRPConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
     }
 
     private DomesticVRPConsent convertEntityToDto(DomesticVRPConsentEntity entity) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
@@ -18,15 +18,20 @@ package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.vrp.v3_1_10;
 import java.util.UUID;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.BaseControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers;
 
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 
 
-public class DomesticVRPConsentApiControllerTest extends BasePaymentConsentApiControllerTest<DomesticVRPConsent, CreateDomesticVRPConsentRequest> {
+public class DomesticVRPConsentApiControllerTest extends BaseControllerTest<DomesticVRPConsent, CreateDomesticVRPConsentRequest, AuthorisePaymentConsentRequest> {
+
+    private static final String TEST_DEBTOR_ACC_ID = "acc-435345";
 
     public DomesticVRPConsentApiControllerTest() {
         super(DomesticVRPConsent.class);
@@ -40,6 +45,31 @@ public class DomesticVRPConsentApiControllerTest extends BasePaymentConsentApiCo
     @Override
     protected CreateDomesticVRPConsentRequest buildCreateConsentRequest(String apiClientId) {
         return buildCreateDomesticVRPConsentRequest(apiClientId, UUID.randomUUID().toString());
+    }
+
+    @Override
+    protected AuthorisePaymentConsentRequest buildAuthoriseConsentRequest(DomesticVRPConsent consent, String resourceOwnerId) {
+        final AuthorisePaymentConsentRequest authoriseReq = new AuthorisePaymentConsentRequest();
+        authoriseReq.setConsentId(consent.getId());
+        authoriseReq.setApiClientId(consent.getApiClientId());
+        authoriseReq.setResourceOwnerId(resourceOwnerId);
+        authoriseReq.setAuthorisedDebtorAccountId(TEST_DEBTOR_ACC_ID);
+        return authoriseReq;
+    }
+
+    @Override
+    protected void validateCreateConsentAgainstCreateRequest(DomesticVRPConsent consent, CreateDomesticVRPConsentRequest createConsentRequest) {
+        PaymentConsentValidationHelpers.validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Override
+    protected void validateAuthorisedConsent(DomesticVRPConsent authorisedConsent, AuthorisePaymentConsentRequest authoriseConsentReq, DomesticVRPConsent originalConsent) {
+        PaymentConsentValidationHelpers.validateAuthorisedConsent(authorisedConsent, authoriseConsentReq, originalConsent);
+    }
+
+    @Override
+    protected void validateRejectedConsent(DomesticVRPConsent rejectedConsent, RejectConsentRequest rejectConsentRequest, DomesticVRPConsent originalConsent) {
+        PaymentConsentValidationHelpers.validateRejectedConsent(rejectedConsent, rejectConsentRequest, originalConsent);
     }
 
     private static CreateDomesticVRPConsentRequest buildCreateDomesticVRPConsentRequest(String apiClientId, String idempotencyKey) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
@@ -18,7 +18,6 @@ package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.vrp.v3_1_10;
 import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 
@@ -34,7 +33,5 @@ public interface DomesticVRPConsentStoreClient {
     DomesticVRPConsent authoriseConsent(AuthorisePaymentConsentRequest authorisePaymentConsentRequest) throws ConsentStoreClientException;
 
     DomesticVRPConsent rejectConsent(RejectConsentRequest rejectDomesticVRPConsentRequest) throws ConsentStoreClientException;
-
-    DomesticVRPConsent consumeConsent(ConsumePaymentConsentRequest consumePaymentConsentRequest) throws ConsentStoreClientException;
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
@@ -27,7 +27,6 @@ import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientConf
 import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
@@ -76,13 +75,6 @@ public class RestDomesticVRPConsentStoreClient extends BaseRestConsentStoreClien
     public DomesticVRPConsent rejectConsent(RejectConsentRequest rejectRequest) throws ConsentStoreClientException {
         final String url = consentServiceBaseUrl + "/" + rejectRequest.getConsentId() + "/reject";
         final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
-        return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
-    }
-
-    @Override
-    public DomesticVRPConsent consumeConsent(ConsumePaymentConsentRequest consumeRequest) throws ConsentStoreClientException {
-        final String url = consentServiceBaseUrl + "/" + consumeRequest.getConsentId() + "/consume";
-        final HttpEntity<ConsumePaymentConsentRequest> requestEntity = new HttpEntity<>(consumeRequest, createHeaders(consumeRequest.getApiClientId()));
         return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
@@ -17,7 +17,6 @@ package com.forgerock.sapi.gateway.rcs.conent.store.client.payment.vrp.v3_1_10;
 
 import static com.forgerock.sapi.gateway.rcs.conent.store.client.TestConsentStoreClientConfigurationFactory.createConsentStoreClientConfiguration;
 import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateAuthorisedConsent;
-import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateConsumedConsent;
 import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateCreateConsentAgainstCreateRequest;
 import static com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers.validateRejectedConsent;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,11 +45,9 @@ import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientExce
 import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException.ErrorType;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"rcs.consent.store.api.baseUri= 'ignored'"})
@@ -118,21 +115,6 @@ class DomesticVRPConsentStoreClientTest {
     }
 
     @Test
-    void testConsumeConsent() {
-        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
-        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
-
-        final AuthorisePaymentConsentRequest authRequest = buildAuthoriseConsentRequest(consent, "psu4test", "acc-12345");
-        final DomesticVRPConsent authResponse = apiClient.authoriseConsent(authRequest);
-        assertThat(authResponse.getStatus()).isEqualTo(StatusEnum.AUTHORISED.toString());
-
-        final DomesticVRPConsent consumedConsent = apiClient.consumeConsent(buildConsumeRequest(consent));
-        assertThat(consumedConsent.getStatus()).isEqualTo(StatusEnum.CONSUMED.toString());
-
-        validateConsumedConsent(consumedConsent, authResponse);
-    }
-
-    @Test
     void testGetConsent() {
         final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
         final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
@@ -168,13 +150,6 @@ class DomesticVRPConsentStoreClientTest {
         rejectRequest.setConsentId(consent.getId());
         rejectRequest.setResourceOwnerId(resourceOwnerId);
         return rejectRequest;
-    }
-
-    private static ConsumePaymentConsentRequest buildConsumeRequest(DomesticVRPConsent consent) {
-        final ConsumePaymentConsentRequest consumeRequest = new ConsumePaymentConsentRequest();
-        consumeRequest.setApiClientId(consent.getApiClientId());
-        consumeRequest.setConsentId((consent.getId()));
-        return consumeRequest;
     }
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
@@ -23,6 +23,7 @@ public class ConsentStoreException extends RuntimeException {
         BAD_REQUEST,
         INVALID_STATE_TRANSITION,
         INVALID_CONSENT_DECISION,
+        CONSENT_REAUTHENTICATION_NOT_SUPPORTED,
         IDEMPOTENCY_ERROR
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentService.java
@@ -40,4 +40,9 @@ public interface ConsentService<T extends BaseConsentEntity, A extends Authorise
 
     void deleteConsent(String consentId, String apiClientId);
 
+    /**
+     * Can the Consent transition from its current state to Authorised state
+     */
+    boolean canTransitionToAuthorisedState(T consent);
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/AccountAccessConsentStateModel.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/AccountAccessConsentStateModel.java
@@ -27,6 +27,8 @@ import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
 /**
  * State Model for Account Access Consents: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/aisp/account-access-consents.html#status-flow
  *
+ * Account Access Consents are long-lived, and support re-authentication.
+ *
  * Note: When a Consent is revoked (consent was previously authorised), it goes to rejected state. In previous versions of the
  * OBIE API, there was a specific revoked state.
  */
@@ -45,11 +47,10 @@ public class AccountAccessConsentStateModel implements ConsentStateModel {
     private final MultiValueMap<String, String> stateTransitions;
 
 
-
     private AccountAccessConsentStateModel() {
         stateTransitions = new LinkedMultiValueMap<>();
         stateTransitions.addAll(AWAITING_AUTHORISATION, List.of(AUTHORISED, REJECTED));
-        stateTransitions.addAll(AUTHORISED, List.of(REJECTED));
+        stateTransitions.addAll(AUTHORISED, List.of(AUTHORISED, REJECTED)); // Authorised has a self link as consent Re-Authentication is supported
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/PaymentConsentStateModel.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/PaymentConsentStateModel.java
@@ -27,6 +27,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.
 /**
  * State model for Payment APIs: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/domestic-payment-consents.html#payment-order-consent
  *
+ * Payments are short-lived consents, and therefore do not support re-authentication.
+ *
  * File payments have a different model, see {@link com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.file.FilePaymentConsentStateModel}
  */
 public class PaymentConsentStateModel implements ConsentStateModel {
@@ -77,4 +79,5 @@ public class PaymentConsentStateModel implements ConsentStateModel {
     public MultiValueMap<String, String> getValidStateTransitions() {
         return new LinkedMultiValueMap<>(stateTransitions);
     }
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentService.java
@@ -16,8 +16,8 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
 
-public interface DomesticVRPConsentService extends PaymentConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> {
+public interface DomesticVRPConsentService extends ConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> {
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/VRPConsentStateModel.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/VRPConsentStateModel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.file;
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
 
 import java.util.List;
 
@@ -22,37 +22,41 @@ import org.springframework.util.MultiValueMap;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
 
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data.StatusEnum;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
 
 /**
- * State Model for File Payment Consents: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/file-payment-consents.html#state-model
+ * State model for VRP Payment APIs: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html#state-model-vrp-consents
+ *
+ * VRPs share a similar state model to Account Access Consents (and other long-lived Consents), they support re-authentication and
+ * unlike other payments cannot be consumed (because they are recurring).
  */
-public class FilePaymentConsentStateModel implements ConsentStateModel {
+public class VRPConsentStateModel implements ConsentStateModel {
 
-    public static final String AWAITING_UPLOAD = StatusEnum.AWAITINGUPLOAD.toString();
     public static final String AWAITING_AUTHORISATION = StatusEnum.AWAITINGAUTHORISATION.toString();
+
     public static final String AUTHORISED = StatusEnum.AUTHORISED.toString();
+
     public static final String CONSUMED = StatusEnum.CONSUMED.toString();
+
     public static final String REJECTED = StatusEnum.REJECTED.toString();
 
-    private static final FilePaymentConsentStateModel INSTANCE = new FilePaymentConsentStateModel();
+    private static final VRPConsentStateModel INSTANCE = new VRPConsentStateModel();
 
-    public static FilePaymentConsentStateModel getInstance() {
+    public static VRPConsentStateModel getInstance() {
         return INSTANCE;
     }
 
     private final MultiValueMap<String, String> stateTransitions;
 
-    private FilePaymentConsentStateModel() {
+    private VRPConsentStateModel() {
         stateTransitions = new LinkedMultiValueMap<>();
-        stateTransitions.addAll(AWAITING_UPLOAD, List.of(AWAITING_AUTHORISATION));
         stateTransitions.addAll(AWAITING_AUTHORISATION, List.of(AUTHORISED, REJECTED));
-        stateTransitions.addAll(AUTHORISED, List.of(CONSUMED));
+        stateTransitions.addAll(AUTHORISED, List.of(AUTHORISED, REJECTED)); // Authorised has a self link as consent Re-Authentication is supported
     }
 
     @Override
     public String getInitialConsentStatus() {
-        return AWAITING_UPLOAD;
+        return AWAITING_AUTHORISATION;
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentServiceTest.java
@@ -15,10 +15,14 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import java.util.List;
 import java.util.UUID;
 
+import org.assertj.core.api.Assertions;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +34,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerTy
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
@@ -40,10 +45,15 @@ import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFac
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-public class DefaultDomesticVRPConsentServiceTest extends BasePaymentConsentServiceTest<DomesticVRPConsentEntity> {
+public class DefaultDomesticVRPConsentServiceTest extends BaseConsentServiceTest<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> {
 
     @Autowired
     private DefaultDomesticVRPConsentService service;
+
+    @Override
+    protected ConsentStateModel getConsentStateModel() {
+        return VRPConsentStateModel.getInstance();
+    }
 
     @Override
     protected BaseConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> getConsentServiceToTest() {
@@ -54,6 +64,23 @@ public class DefaultDomesticVRPConsentServiceTest extends BasePaymentConsentServ
     protected DomesticVRPConsentEntity getValidConsentEntity() {
         final String apiClientId = "test-client-987";
         return createValidConsentEntity(apiClientId);
+    }
+
+    @Override
+    protected PaymentAuthoriseConsentArgs getAuthoriseConsentArgs(String consentId, String resourceOwnerId, String apiClientId) {
+        return new PaymentAuthoriseConsentArgs(consentId, apiClientId, resourceOwnerId, "debtor-acc-444");
+    }
+
+    @Override
+    protected void validateConsentSpecificFields(DomesticVRPConsentEntity expected, DomesticVRPConsentEntity actual) {
+        assertThat(actual.getIdempotencyKey()).isEqualTo(expected.getIdempotencyKey());
+        assertThat(actual.getIdempotencyKeyExpiration()).isEqualTo(expected.getIdempotencyKeyExpiration());
+        assertThat(actual.getCharges()).isEqualTo(expected.getCharges());
+    }
+
+    @Override
+    protected void validateConsentSpecificAuthorisationFields(DomesticVRPConsentEntity authorisedConsent, PaymentAuthoriseConsentArgs authorisationArgs) {
+        assertThat(authorisedConsent.getAuthorisedDebtorAccountId()).isEqualTo(authorisationArgs.getAuthorisedDebtorAccountId());
     }
 
     public static DomesticVRPConsentEntity createValidConsentEntity(String apiClientId) {
@@ -79,6 +106,13 @@ public class DefaultDomesticVRPConsentServiceTest extends BasePaymentConsentServ
                         .build())
         );
         return vrpConsent;
+    }
+
+    @Test
+    void testConsentCanBeReAuthenticated() {
+        final DomesticVRPConsentEntity consent = createValidConsentEntity("client-id");
+        consent.setStatus(getConsentStateModel().getAuthorisedConsentStatus());
+        Assertions.assertThat(consentService.canTransitionToAuthorisedState(consent)).isTrue();
     }
 
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiController.java
@@ -191,7 +191,7 @@ public class ConsentDecisionApiController implements ConsentDecisionApi {
             throw new InvalidConsentException(consentDecisionDeserialized.getConsentJwt(), INTERNAL_SERVER_ERROR,
                     OBRIErrorType.RCS_CONSENT_RESPONSE_FAILURE, errorMessage, null, null);
         } catch (ConsentStoreException cse) {
-            log.error("Consent Store Exception raise when processing decision", cse);
+            log.error("Consent Store Exception raised when processing decision", cse);
             throw new InvalidConsentException(consentDecisionDeserialized.getConsentJwt(), INTERNAL_SERVER_ERROR,
                     OBRIErrorType.RCS_CONSENT_RESPONSE_FAILURE, "Internal Server Error", null, null);
         }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiController.java
@@ -171,17 +171,22 @@ public class ConsentDetailsApiController implements ConsentDetailsApi {
         final ErrorType errorType;
         final String errorMessage;
         switch (cse.getErrorType()) {
-            case NOT_FOUND:
+            case NOT_FOUND -> {
                 errorType = ErrorType.NOT_FOUND;
                 errorMessage = "Consent Not Found";
-                break;
-            case INVALID_PERMISSIONS:
+            }
+            case INVALID_PERMISSIONS -> {
                 errorType = ErrorType.ACCESS_DENIED;
                 errorMessage = "Access Denied";
-                break;
-            default:
+            }
+            case CONSENT_REAUTHENTICATION_NOT_SUPPORTED -> {
+                errorType = ErrorType.ACCESS_DENIED;
+                errorMessage = "Consent Re-Authentication not supported for this type of consent";
+            }
+            default -> {
                 errorType = ErrorType.INTERNAL_SERVER_ERROR;
                 errorMessage = "Server Error";
+            }
         }
         return new InvalidConsentException(consentRequestJws, errorType, OBRIErrorType.REQUEST_BINDING_FAILED,
                 errorMessage, apiClientId, intentId);

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiControllerRcsConsentStoreTest.java
@@ -81,9 +81,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.internat
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalScheduledPaymentConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentStateModel;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic.DomesticPaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic.DomesticScheduledPaymentConsentService;
@@ -290,7 +290,7 @@ public class ConsentDecisionApiControllerRcsConsentStoreTest {
         throw new UnsupportedOperationException();
     }
 
-    private PaymentConsentService getConsentService(IntentType intentType) {
+    private ConsentService getConsentService(IntentType intentType) {
         switch (intentType) {
         case PAYMENT_DOMESTIC_CONSENT:
             return domesticPaymentConsentService;
@@ -351,7 +351,7 @@ public class ConsentDecisionApiControllerRcsConsentStoreTest {
         verifyConsentResponseJwt(consentResponseJwt);
 
         // Verify consent in store is now authorised
-        final PaymentConsentService consentService = getConsentService(intentType);
+        final ConsentService consentService = getConsentService(intentType);
         final BasePaymentConsentEntity authorisedConsent = (BasePaymentConsentEntity) consentService.getConsent(consent.getId(), consent.getApiClientId());
         assertEquals(PaymentConsentStateModel.AUTHORISED, authorisedConsent.getStatus());
         assertEquals(TEST_RESOURCE_OWNER_ID, authorisedConsent.getResourceOwnerId());
@@ -381,7 +381,7 @@ public class ConsentDecisionApiControllerRcsConsentStoreTest {
         verifyConsentResponseJwt(consentResponseJwt);
 
         // Verify consent in store is now rejected
-        final PaymentConsentService consentService = getConsentService(intentType);
+        final ConsentService consentService = getConsentService(intentType);
         final BasePaymentConsentEntity rejectedConsent = (BasePaymentConsentEntity) consentService.getConsent(consent.getId(), consent.getApiClientId());
         assertEquals(PaymentConsentStateModel.REJECTED, rejectedConsent.getStatus());
         assertEquals(TEST_RESOURCE_OWNER_ID, rejectedConsent.getResourceOwnerId());

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/BasePaymentConsentDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/BasePaymentConsentDecisionServiceTest.java
@@ -30,8 +30,8 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.Constants;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaymentConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 public abstract class BasePaymentConsentDecisionServiceTest<T extends BasePaymentConsentEntity> {
@@ -48,7 +48,7 @@ public abstract class BasePaymentConsentDecisionServiceTest<T extends BasePaymen
         return consentDecision;
     }
 
-    protected abstract PaymentConsentService<T, PaymentAuthoriseConsentArgs> getPaymentConsentService();
+    protected abstract ConsentService<T, PaymentAuthoriseConsentArgs> getPaymentConsentService();
 
     protected abstract BasePaymentConsentDecisionService<T> getConsentDecisionService();
 
@@ -59,7 +59,7 @@ public abstract class BasePaymentConsentDecisionServiceTest<T extends BasePaymen
         final ConsentDecisionDeserialized consentDecision = BasePaymentConsentDecisionServiceTest.createAuthorisePaymentConsentDecision(TEST_AUTHORISED_DEBTOR_ACC_ID);
         getConsentDecisionService().authoriseConsent(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, consentDecision);
 
-        final PaymentConsentService<T, PaymentAuthoriseConsentArgs> paymentConsentService = getPaymentConsentService();
+        final ConsentService<T, PaymentAuthoriseConsentArgs> paymentConsentService = getPaymentConsentService();
         verify(paymentConsentService).authoriseConsent(refEq(new PaymentAuthoriseConsentArgs(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, TEST_AUTHORISED_DEBTOR_ACC_ID)));
         Mockito.verifyNoMoreInteractions(paymentConsentService);
     }

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionServiceTest.java
@@ -23,8 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionServiceTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,7 +38,7 @@ public class DomesticVRPConsentDecisionServiceTest extends BasePaymentConsentDec
 
 
     @Override
-    protected PaymentConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> getPaymentConsentService() {
+    protected ConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> getPaymentConsentService() {
         return domesticPaymentConsentService;
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsServiceTest.java
@@ -17,6 +17,7 @@ package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.BDDMockito.BDDMyOngoingStubbing;
 import org.mockito.Mock;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
@@ -42,6 +42,7 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.User;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.AccountService;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
 
@@ -109,6 +110,10 @@ public class BasePaymentConsentDetailsServiceTest {
 
         final IllegalStateException ex = assertThrows(IllegalStateException.class, () -> BasePaymentConsentDetailsService.computeTotalChargeAmount(charges));
         assertThat(ex.getMessage()).isEqualTo("Charges contain more than 1 currency, all charges must be in the same currency");
+    }
+
+    protected void mockConsentServiceCanAuthorise(ConsentService<?, ?> consentService) {
+        given(consentService.canTransitionToAuthorisedState(any())).willReturn(Boolean.TRUE);
     }
 
     protected void mockApiProviderConfigurationGetName() {

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsServiceTest.java
@@ -66,6 +66,7 @@ class DomesticScheduledPaymentConsentDetailsServiceTest extends BasePaymentConse
         final DomesticScheduledPaymentConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(domesticScheduledPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(domesticScheduledPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -104,6 +105,7 @@ class DomesticScheduledPaymentConsentDetailsServiceTest extends BasePaymentConse
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(domesticScheduledPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(domesticScheduledPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsServiceTest.java
@@ -66,6 +66,7 @@ class DomesticStandingOrderConsentDetailsServiceTest extends BasePaymentConsentD
         final DomesticStandingOrderConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -102,6 +103,7 @@ class DomesticStandingOrderConsentDetailsServiceTest extends BasePaymentConsentD
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/file/FilePaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/file/FilePaymentConsentDetailsServiceTest.java
@@ -67,6 +67,7 @@ class FilePaymentConsentDetailsServiceTest extends BasePaymentConsentDetailsServ
         final FilePaymentConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(filePaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(filePaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -105,6 +106,7 @@ class FilePaymentConsentDetailsServiceTest extends BasePaymentConsentDetailsServ
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(filePaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(filePaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalPaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalPaymentConsentDetailsServiceTest.java
@@ -65,6 +65,7 @@ class InternationalPaymentConsentDetailsServiceTest extends BasePaymentConsentDe
         final InternationalPaymentConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(internationalPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(internationalPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -103,6 +104,7 @@ class InternationalPaymentConsentDetailsServiceTest extends BasePaymentConsentDe
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(internationalPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(internationalPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalScheduledPaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalScheduledPaymentConsentDetailsServiceTest.java
@@ -65,6 +65,7 @@ class InternationalScheduledPaymentConsentDetailsServiceTest extends BasePayment
         final InternationalScheduledPaymentConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(internationalPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(internationalPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -104,6 +105,7 @@ class InternationalScheduledPaymentConsentDetailsServiceTest extends BasePayment
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(internationalPaymentConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(internationalPaymentConsentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsServiceTest.java
@@ -65,6 +65,7 @@ class InternationalStandingOrderConsentDetailsServiceTest extends BasePaymentCon
         final InternationalStandingOrderConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -101,6 +102,7 @@ class InternationalStandingOrderConsentDetailsServiceTest extends BasePaymentCon
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsServiceTest.java
@@ -64,6 +64,7 @@ class DomesticVRPConsentDetailsServiceTest extends BasePaymentConsentDetailsServ
         final DomesticVRPConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
@@ -98,6 +99,7 @@ class DomesticVRPConsentDetailsServiceTest extends BasePaymentConsentDetailsServ
         consentEntity.getRequestObj().getData().getInitiation().setDebtorAccount(FRAccountIdentifierConverter.toFRAccountIdentifier(debtorAccount));
         consentEntity.setId(intentId);
         given(consentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        mockConsentServiceCanAuthorise(consentService);
 
         final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
                 new ConsentClientDetailsRequest(intentId, Mockito.mock(SignedJWT.class), testUser, testApiClient.getId()));


### PR DESCRIPTION
Re-authentication means that a PSU can Authorise (or Reject) a consent that is currently in an Authorised state. This is only supported for long-lived consents, which are currently: Account Access and Domestic VRP consents.

Updating the ConsentStateModel to add support for re-authentication. Adding a new VRPConsentStateModel, and using this for VRP Consents (rather than the PaymentConsentStateModel).

As part of modelling the VRPConsentStateModel, we are also fixing a bug which meant that VRP consents could be Consumed. This state is not supported for VRP payments as they are long-lived (all other payments are short-lived)

Adding new ConsentStoreException error: CONSENT_REAUTHENTICATION_NOT_SUPPORTED, which will be raised if we attempt to fetch the consent details for the UI for a consent that has already been authorised (and re-authentication is not supported).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1047