### PR TITLE
1050: Adding support for deleting Domestic VRP Consents

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApi.java
@@ -121,4 +121,20 @@ public interface DomesticVRPConsentApi {
                                                      @Valid
                                                      @RequestBody RejectConsentRequest request);
 
+
+    @ApiOperation(value = "Delete Domestic VRP Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Delete successful"),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/domestic-vrp-consents/{consentId}",
+            method = RequestMethod.DELETE)
+    ResponseEntity<Void> deleteConsent(@PathVariable(value = "consentId") String consentId,
+                                       @RequestHeader(value = "x-api-client-id") String apiClientId);
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
@@ -105,6 +105,13 @@ public class DomesticVRPConsentApiController implements DomesticVRPConsentApi {
         return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
     }
 
+    @Override
+    public ResponseEntity<Void> deleteConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to deleteConsent - id: {}, apiClientId: {}", consentId, apiClientId);
+        consentService.deleteConsent(consentId, apiClientId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     private DomesticVRPConsent convertEntityToDto(DomesticVRPConsentEntity entity) {
         final DomesticVRPConsent dto = new DomesticVRPConsent();
         dto.setId(entity.getId());

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClient.java
@@ -34,4 +34,6 @@ public interface DomesticVRPConsentStoreClient {
 
     DomesticVRPConsent rejectConsent(RejectConsentRequest rejectDomesticVRPConsentRequest) throws ConsentStoreClientException;
 
+    void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/RestDomesticVRPConsentStoreClient.java
@@ -78,4 +78,11 @@ public class RestDomesticVRPConsentStoreClient extends BaseRestConsentStoreClien
         return doRestCall(url, HttpMethod.POST, requestEntity, DomesticVRPConsent.class);
     }
 
+    @Override
+    public void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        doRestCall(url, HttpMethod.DELETE, requestEntity, Void.class);
+    }
+
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/conent/store/client/payment/vrp/v3_1_10/DomesticVRPConsentStoreClientTest.java
@@ -122,6 +122,13 @@ class DomesticVRPConsentStoreClientTest {
         assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
     }
 
+    @Test
+    void testDeleteConsent() {
+        final CreateDomesticVRPConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final DomesticVRPConsent consent = apiClient.createConsent(createConsentRequest);
+        apiClient.deleteConsent(consent.getId(), consent.getApiClientId());
+    }
+
     private static CreateDomesticVRPConsentRequest buildCreateConsentRequest() {
         final CreateDomesticVRPConsentRequest createConsentRequest = new CreateDomesticVRPConsentRequest();
         createConsentRequest.setIdempotencyKey(UUID.randomUUID().toString());


### PR DESCRIPTION
Domestic VRP Consents are long-lived and support delete (revoking) consent.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1050