### PR TITLE
1069: added customer info APIs and store client with test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.5</uk.bom.version>
+        <uk.bom.version>1.0.6-SNAPSHOT</uk.bom.version>
         <gson.version>2.10.1</gson.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>

--- a/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/CustomerInfoConsentDetails.java
+++ b/secure-api-gateway-ob-uk-rcs-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/api/dto/consent/details/CustomerInfoConsentDetails.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRExternalPermissionsCode;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import uk.org.openbanking.datamodel.customerinfo.CustomerInfo;
+
+import java.util.List;
+
+/**
+ * Models the customer info data that is used for an customer info details request.
+ */
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerInfoConsentDetails extends ConsentDetails {
+
+    private List<FRExternalPermissionsCode> permissions;
+    private FRCustomerInfo customerInfo;
+
+    @Override
+    public IntentType getIntentType() {
+        return IntentType.CUSTOMER_INFO_CONSENT;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApi.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import io.swagger.annotations.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+
+import javax.validation.Valid;
+
+@Validated
+@Api(tags = {"v1.0"})
+@RequestMapping(value = "/consent/store/v1.0")
+public interface CustomerInfoConsentApi {
+
+    @ApiOperation(value = "Create Customer Info Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "CustomerInfoConsent object representing the consent created",
+                    response = CustomerInfoConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/customer-info-consents",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<CustomerInfoConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                      @Valid
+                                                      @RequestBody CreateCustomerInfoConsentRequest request);
+
+
+    @ApiOperation(value = "Get Customer Info Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "CustomerInfoConsent object representing the consent created",
+                    response = CustomerInfoConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/customer-info-consents/{consentId}",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
+    ResponseEntity<CustomerInfoConsent> getConsent(@PathVariable(value = "consentId") String consentId,
+                                                   @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Authorise Customer Info Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "CustomerInfoConsent object representing the consent created",
+                    response = CustomerInfoConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/customer-info-consents/{consentId}/authorise",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<CustomerInfoConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
+                                                         @ApiParam(value = "Authorise Consent Request", required = true)
+                                                         @Valid
+                                                         @RequestBody AuthoriseCustomerInfoConsentRequest request);
+
+
+    @ApiOperation(value = "Reject Customer Info Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "CustomerInfoConsent object representing the consent created",
+                    response = CustomerInfoConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/customer-info-consents/{consentId}/reject",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<CustomerInfoConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
+                                                      @ApiParam(value = "Reject Consent Request", required = true)
+                                                      @Valid
+                                                      @RequestBody RejectConsentRequest request);
+
+
+    @ApiOperation(value = "Delete Customer Info Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Delete successful"),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/customer-info-consents/{consentId}",
+            method = RequestMethod.DELETE)
+    ResponseEntity<Void> deleteConsent(@PathVariable(value = "consentId") String consentId,
+                                       @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiController.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.Objects;
+
+@Controller
+@Slf4j
+public class CustomerInfoConsentApiController implements CustomerInfoConsentApi {
+
+    private final CustomerInfoConsentService consentService;
+    private final OBVersion obVersion;
+
+    @Autowired
+    public CustomerInfoConsentApiController(CustomerInfoConsentService consentService) {
+        this(consentService, OBVersion.v1_0);
+    }
+
+    public CustomerInfoConsentApiController(CustomerInfoConsentService consentService, OBVersion obVersion) {
+        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
+        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
+    }
+
+    @Override
+    public ResponseEntity<CustomerInfoConsent> createConsent(CreateCustomerInfoConsentRequest request) {
+        log.info("Attempting to createConsent: {}", request);
+        final CustomerInfoConsentEntity consentEntity = new CustomerInfoConsentEntity();
+        consentEntity.setRequestObj(request.getConsentRequest());
+        consentEntity.setApiClientId(request.getApiClientId());
+        consentEntity.setRequestVersion(obVersion);
+        consentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
+
+        final CustomerInfoConsentEntity persistedEntity = consentService.createConsent(consentEntity);
+        log.info("Consent created with id: {}", persistedEntity.getId());
+        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<CustomerInfoConsent> getConsent(String consentId, String apiClientId) {
+        log.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
+    }
+
+    @Override
+    public ResponseEntity<CustomerInfoConsent> authoriseConsent(
+            String consentId,
+            AuthoriseCustomerInfoConsentRequest request
+    ) {
+        log.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final CustomerInfoAuthoriseConsentArgs authoriseArgs = new CustomerInfoAuthoriseConsentArgs(
+                consentId,
+                request.getApiClientId(),
+                request.getResourceOwnerId()
+        );
+        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(authoriseArgs)));
+    }
+
+    @Override
+    public ResponseEntity<CustomerInfoConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        log.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(
+                convertEntityToDto(
+                        consentService.rejectConsent(
+                                consentId,
+                                request.getApiClientId(),
+                                request.getResourceOwnerId()
+                        )
+                )
+        );
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteConsent(String consentId, String apiClientId) {
+        log.info("Attempting to deleteConsent - id: {}, apiClientId: {}", consentId, apiClientId);
+        consentService.deleteConsent(consentId, apiClientId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    private CustomerInfoConsent convertEntityToDto(CustomerInfoConsentEntity entity) {
+        final CustomerInfoConsent dto = new CustomerInfoConsent();
+        dto.setApiClientId(entity.getApiClientId());
+        dto.setId(entity.getId());
+        dto.setCreationDateTime(entity.getCreationDateTime());
+        dto.setStatus(entity.getStatus());
+        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
+        dto.setRequestVersion(entity.getRequestVersion());
+        dto.setRequestObj(entity.getRequestObj());
+        dto.setResourceOwnerId(entity.getResourceOwnerId());
+        return dto;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiControllerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.BaseControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.account.OBReadData1;
+import uk.org.openbanking.datamodel.account.OBRisk2;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+public class CustomerInfoConsentApiControllerTest extends BaseControllerTest<CustomerInfoConsent, CreateCustomerInfoConsentRequest, AuthoriseCustomerInfoConsentRequest> {
+
+
+    protected CustomerInfoConsentApiControllerTest() {
+        super(CustomerInfoConsent.class);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        apiBaseUrl = "http://localhost:" + port + "/consent/store/v1.0/" + getControllerEndpointName();
+    }
+
+    @Override
+    protected String getControllerEndpointName() {
+        return "customer-info-consents";
+    }
+
+    @Override
+    protected CreateCustomerInfoConsentRequest buildCreateConsentRequest(String apiClientId) {
+        final CreateCustomerInfoConsentRequest createRequest = new CreateCustomerInfoConsentRequest();
+        createRequest.setApiClientId(apiClientId);
+        createRequest.setConsentRequest(FRReadConsentConverter.toFRReadConsent(new OBReadConsent1()
+                .data(new OBReadData1().permissions(List.of(OBExternalPermissions1Code.READCUSTOMERINFO)))
+                .risk(new OBRisk2())));
+        return createRequest;
+    }
+
+    @Override
+    protected void validateCreateConsentAgainstCreateRequest(CustomerInfoConsent consent, CreateCustomerInfoConsentRequest createConsentRequest) {
+        CustomerInfoConsentValidationHelpers.validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Override
+    protected AuthoriseCustomerInfoConsentRequest buildAuthoriseConsentRequest(CustomerInfoConsent consent, String resourceOwnerId) {
+        AuthoriseCustomerInfoConsentRequest authoriseCustomerInfoConsentRequest = new AuthoriseCustomerInfoConsentRequest();
+        authoriseCustomerInfoConsentRequest.setConsentId(consent.getId());
+        authoriseCustomerInfoConsentRequest.setApiClientId(consent.getApiClientId());
+        authoriseCustomerInfoConsentRequest.setResourceOwnerId(resourceOwnerId);
+        return authoriseCustomerInfoConsentRequest;
+    }
+
+    @Override
+    protected void validateAuthorisedConsent(CustomerInfoConsent authorisedConsent, AuthoriseCustomerInfoConsentRequest authoriseConsentReq, CustomerInfoConsent originalConsent) {
+        CustomerInfoConsentValidationHelpers.validateAuthorisedConsent(authorisedConsent, authoriseConsentReq, originalConsent);
+    }
+
+    @Override
+    protected void validateRejectedConsent(CustomerInfoConsent rejectedConsent, RejectConsentRequest rejectConsentRequest, CustomerInfoConsent originalConsent) {
+        CustomerInfoConsentValidationHelpers.validateRejectedConsent(rejectedConsent, rejectConsentRequest, originalConsent);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentValidationHelpers.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentValidationHelpers.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+;
+
+/**
+ * Helper methods for validating {@link CustomerInfoConsent} objects as part of using the {@link CustomerInfoConsentApi}
+ */
+public class CustomerInfoConsentValidationHelpers {
+
+    public static void validateCreateConsentAgainstCreateRequest(CustomerInfoConsent consent,
+                                                                 CreateCustomerInfoConsentRequest createCustomerInfoConsentRequest) {
+        assertThat(consent.getId()).isNotEmpty();
+        assertThat(consent.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION.toString());
+        assertThat(consent.getApiClientId()).isEqualTo(createCustomerInfoConsentRequest.getApiClientId());
+        assertThat(consent.getRequestObj()).isEqualTo(createCustomerInfoConsentRequest.getConsentRequest());
+        assertThat(consent.getRequestVersion()).isEqualTo(OBVersion.v1_0);
+        assertThat(consent.getResourceOwnerId()).isNull();
+        assertThat(consent.getCreationDateTime()).isLessThan(DateTime.now());
+        assertThat(consent.getStatusUpdateDateTime()).isEqualTo(consent.getCreationDateTime());
+    }
+
+    public static void validateAuthorisedConsent(CustomerInfoConsent authorisedConsent, AuthoriseCustomerInfoConsentRequest authoriseReq, CustomerInfoConsent originalConsent) {
+        assertThat(authorisedConsent.getStatus()).isEqualTo(StatusEnum.AUTHORISED.toString());
+        assertThat(authorisedConsent.getResourceOwnerId()).isEqualTo(authoriseReq.getResourceOwnerId());
+        validateUpdatedConsentAgainstOriginal(authorisedConsent, originalConsent);
+    }
+
+    public static void validateRejectedConsent(CustomerInfoConsent rejectedConsent, RejectConsentRequest rejectReq, CustomerInfoConsent originalConsent) {
+        assertThat(rejectedConsent.getStatus()).isEqualTo(StatusEnum.REJECTED.toString());
+        assertThat(rejectedConsent.getResourceOwnerId()).isEqualTo(rejectReq.getResourceOwnerId());
+        validateUpdatedConsentAgainstOriginal(rejectedConsent, originalConsent);
+    }
+
+    /**
+     * Validates fields in an updatedConsent vs an original consent.
+     *
+     * This checks that fields that should never change when a consent is updated do never change, and verifies that
+     * the statusUpdateDateTime increases vs the original.
+     */
+    public static void validateUpdatedConsentAgainstOriginal(CustomerInfoConsent updatedConsent, CustomerInfoConsent consent) {
+        assertThat(updatedConsent.getId()).isEqualTo(consent.getId());
+        assertThat(updatedConsent.getApiClientId()).isEqualTo(consent.getApiClientId());
+        assertThat(updatedConsent.getRequestObj()).isEqualTo(consent.getRequestObj());
+        assertThat(updatedConsent.getRequestVersion()).isEqualTo(consent.getRequestVersion());
+        assertThat(updatedConsent.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
+        assertThat(updatedConsent.getStatusUpdateDateTime()).isLessThanOrEqualTo(DateTime.now()).isGreaterThan(consent.getStatusUpdateDateTime());
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/CustomerInfoConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/CustomerInfoConsentStoreClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+
+/**
+ * Client for interacting with com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0.CustomerInfoConsentApi
+ */
+public interface CustomerInfoConsentStoreClient {
+    CustomerInfoConsent createConsent(CreateCustomerInfoConsentRequest createConsentRequest) throws ConsentStoreClientException;
+
+    CustomerInfoConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
+    CustomerInfoConsent authoriseConsent(AuthoriseCustomerInfoConsentRequest authoriseAccountAccessConsentRequest) throws ConsentStoreClientException;
+
+    CustomerInfoConsent rejectConsent(RejectConsentRequest rejectAccountAccessConsentRequest) throws ConsentStoreClientException;
+
+    void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/RestCustomerInfoConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/RestCustomerInfoConsentStoreClient.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.customerinfo.v1_0;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.BaseRestConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class RestCustomerInfoConsentStoreClient extends BaseRestConsentStoreClient implements CustomerInfoConsentStoreClient {
+
+    private final String consentServiceBaseUrl;
+
+    @Autowired
+    public RestCustomerInfoConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration,
+                                              RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+
+        this(consentStoreClientConfiguration, restTemplateBuilder, objectMapper, OBVersion.v1_0);
+    }
+
+    public RestCustomerInfoConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration,
+                                              RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper,
+                                              OBVersion obVersion) {
+        super(restTemplateBuilder, objectMapper);
+        Objects.requireNonNull(consentStoreClientConfiguration, "consentStoreClientConfiguration must be provided");
+        this.consentServiceBaseUrl = consentStoreClientConfiguration.getBaseUri() + "/" + obVersion.getCanonicalName() + "/customer-info-consents";
+    }
+
+
+    @Override
+    public CustomerInfoConsent createConsent(CreateCustomerInfoConsentRequest createConsentRequest) throws ConsentStoreClientException {
+        final HttpEntity<CreateCustomerInfoConsentRequest> requestEntity = new HttpEntity<>(createConsentRequest, createHeaders(createConsentRequest.getApiClientId()));
+        return doRestCall(consentServiceBaseUrl, HttpMethod.POST, requestEntity, CustomerInfoConsent.class);
+    }
+
+    @Override
+    public CustomerInfoConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        return doRestCall(url, HttpMethod.GET, requestEntity, CustomerInfoConsent.class);
+    }
+
+    @Override
+    public CustomerInfoConsent authoriseConsent(AuthoriseCustomerInfoConsentRequest authRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + authRequest.getConsentId() + "/authorise";
+        final HttpEntity<AuthoriseCustomerInfoConsentRequest> requestEntity = new HttpEntity<>(authRequest, createHeaders(authRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, CustomerInfoConsent.class);
+    }
+
+    @Override
+    public CustomerInfoConsent rejectConsent(RejectConsentRequest rejectRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + rejectRequest.getConsentId() + "/reject";
+        final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, CustomerInfoConsent.class);
+    }
+
+    @Override
+    public void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        doRestCall(url, HttpMethod.DELETE, requestEntity, Void.class);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/CustomerInfoConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/client/customerinfo/v1_0/CustomerInfoConsentStoreClientTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.customerinfo.v1_0;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.AuthoriseCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CreateCustomerInfoConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0.CustomerInfoConsent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.account.OBReadData1;
+import uk.org.openbanking.datamodel.account.OBRisk2;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0.CustomerInfoConsentValidationHelpers.*;
+import static com.forgerock.sapi.gateway.rcs.consent.store.client.TestConsentStoreClientConfigurationFactory.createConsentStoreClientConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Test for {@link CustomerInfoConsentStoreClient}
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"rcs.consent.store.api.baseUri= 'ignored'"})
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+public class CustomerInfoConsentStoreClientTest {
+
+    private static final String API_CLIENT_ID = UUID.randomUUID().toString();
+    private static final String RESOURCE_OWNER_ID = UUID.randomUUID().toString();
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private RestCustomerInfoConsentStoreClient storeApiClient;
+
+    @BeforeEach
+    public void beforeEach() {
+        storeApiClient = new RestCustomerInfoConsentStoreClient(createConsentStoreClientConfiguration(port), restTemplateBuilder, objectMapper);
+    }
+
+    @Test
+    void testCreateConsent() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final CustomerInfoConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Test
+    void failsToCreateConsentWhenFieldIsMissing() {
+        final CreateCustomerInfoConsentRequest requestMissingConsentReqField = new CreateCustomerInfoConsentRequest();
+        requestMissingConsentReqField.setApiClientId(API_CLIENT_ID);
+
+        final ConsentStoreClientException clientException = assertThrows(ConsentStoreClientException.class,
+                () -> storeApiClient.createConsent(requestMissingConsentReqField));
+        assertThat(clientException.getErrorType()).isEqualTo(ConsentStoreClientException.ErrorType.BAD_REQUEST);
+        assertThat(clientException.getObError1()).isNotNull();
+        assertThat(clientException.getObError1().getErrorCode()).isEqualTo("UK.OBIE.Field.Invalid");
+        assertThat(clientException.getObError1().getMessage()).isEqualTo("The field received is invalid. Reason 'must not be null'");
+        assertThat(clientException.getObError1().getPath()).isEqualTo("consentRequest");
+    }
+
+    @Test
+    void testAuthoriseConsent() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final CustomerInfoConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        final AuthoriseCustomerInfoConsentRequest authRequest = buildAuthoriseConsentRequest(consent);
+        final CustomerInfoConsent authResponse = storeApiClient.authoriseConsent(authRequest);
+
+        validateAuthorisedConsent(authResponse, authRequest, consent);
+    }
+
+    @Test
+    void testRejectConsent() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final CustomerInfoConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        final RejectConsentRequest rejectRequest = buildRejectRequest(consent);
+        final CustomerInfoConsent rejectedConsent = storeApiClient.rejectConsent(rejectRequest);
+        validateRejectedConsent(rejectedConsent, rejectRequest, consent);
+    }
+
+    @Test
+    void testGetConsent() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final CustomerInfoConsent consent = storeApiClient.createConsent(createConsentRequest);
+        final CustomerInfoConsent getResponse = storeApiClient.getConsent(consent.getId(), consent.getApiClientId());
+        assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
+    }
+
+    @Test
+    void testDeleteConsent() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final CustomerInfoConsent consent = storeApiClient.createConsent(createConsentRequest);
+        storeApiClient.deleteConsent(consent.getId(), consent.getApiClientId());
+    }
+
+    private static CreateCustomerInfoConsentRequest buildCreateConsentRequest() {
+        final CreateCustomerInfoConsentRequest createConsentRequest = new CreateCustomerInfoConsentRequest();
+        createConsentRequest.setApiClientId(API_CLIENT_ID);
+        createConsentRequest.setConsentRequest(FRReadConsentConverter.toFRReadConsent(new OBReadConsent1()
+                .data(new OBReadData1().permissions(List.of(OBExternalPermissions1Code.READCUSTOMERINFO)))
+                .risk(new OBRisk2())));
+        return createConsentRequest;
+    }
+
+    private static AuthoriseCustomerInfoConsentRequest buildAuthoriseConsentRequest(CustomerInfoConsent consent) {
+        final AuthoriseCustomerInfoConsentRequest authRequest = new AuthoriseCustomerInfoConsentRequest();
+        authRequest.setConsentId(consent.getId());
+        authRequest.setResourceOwnerId(RESOURCE_OWNER_ID);
+        authRequest.setApiClientId(consent.getApiClientId());
+        return authRequest;
+    }
+
+    private static RejectConsentRequest buildRejectRequest(CustomerInfoConsent consent) {
+        final RejectConsentRequest rejectRequest = new RejectConsentRequest();
+        rejectRequest.setApiClientId(consent.getApiClientId());
+        rejectRequest.setConsentId(consent.getId());
+        rejectRequest.setResourceOwnerId(RESOURCE_OWNER_ID);
+        return rejectRequest;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/AuthoriseCustomerInfoConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/AuthoriseCustomerInfoConsentRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseAuthoriseConsentRequest;
+
+public class AuthoriseCustomerInfoConsentRequest extends BaseAuthoriseConsentRequest {
+    @Override
+    public String toString() {
+        return "AuthoriseCustomerInfoConsentRequest{" +
+                "consentId='" + getConsentId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                '}';
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/CreateCustomerInfoConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/CreateCustomerInfoConsentRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRReadConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseCreateConsentRequest;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class CreateCustomerInfoConsentRequest extends BaseCreateConsentRequest<FRReadConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/CustomerInfoConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/customerinfo/v1_0/CustomerInfoConsent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.customerinfo.v1_0;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRReadConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseConsent;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Customer Info Consent
+ */
+@Validated
+public class CustomerInfoConsent extends BaseConsent<FRReadConsent> {
+    @Override
+    public String toString() {
+        return "CustomerInfoConsent{" +
+                "id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/customerinfo/CustomerInfoConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/customerinfo/CustomerInfoConsentEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRReadConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.BaseConsentEntity;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Customer info consent entity
+ */
+@Document("CustomerInfoConsent")
+@Validated
+public class CustomerInfoConsentEntity extends BaseConsentEntity<FRReadConsent> {
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/customerinfo/CustomerInfoConsentRepository.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/customerinfo/CustomerInfoConsentRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.customerinfo;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface CustomerInfoConsentRepository extends MongoRepository<CustomerInfoConsentEntity, String> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoAuthoriseConsentArgs.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoAuthoriseConsentArgs.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.AuthoriseConsentArgs;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class CustomerInfoAuthoriseConsentArgs extends AuthoriseConsentArgs {
+
+    public CustomerInfoAuthoriseConsentArgs(String consentId, String apiClientId, String resourceOwnerId) {
+        super(consentId, resourceOwnerId, apiClientId);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
+
+public interface CustomerInfoConsentService extends ConsentService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentStateModel.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentStateModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.List;
+
+/**
+ * State Model for Customer info Consents, following the same status model of {@link com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel}
+ *
+ * Account Access Consents are long-lived, and support re-authentication.
+ *
+ * Note: When a Consent is revoked (consent was previously authorised), it goes to rejected state. In previous versions of the
+ * OBIE API, there was a specific revoked state.
+ */
+public class CustomerInfoConsentStateModel implements ConsentStateModel {
+
+    public static final String AWAITING_AUTHORISATION = OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString();
+    public static final String AUTHORISED = OBExternalRequestStatus1Code.AUTHORISED.toString();
+    public static final String REJECTED = OBExternalRequestStatus1Code.REJECTED.toString();
+
+    private static final CustomerInfoConsentStateModel INSTANCE = new CustomerInfoConsentStateModel();
+
+    public static CustomerInfoConsentStateModel getInstance() {
+        return INSTANCE;
+    }
+
+    private final MultiValueMap<String, String> stateTransitions;
+
+
+    private CustomerInfoConsentStateModel() {
+        stateTransitions = new LinkedMultiValueMap<>();
+        stateTransitions.addAll(AWAITING_AUTHORISATION, List.of(AUTHORISED, REJECTED));
+        stateTransitions.addAll(AUTHORISED, List.of(AUTHORISED, REJECTED)); // Authorised has a self link as consent Re-Authentication is supported
+    }
+
+    @Override
+    public String getInitialConsentStatus() {
+        return AWAITING_AUTHORISATION;
+    }
+
+    @Override
+    public String getAuthorisedConsentStatus() {
+        return AUTHORISED;
+    }
+
+    @Override
+    public String getRejectedConsentStatus() {
+        return REJECTED;
+    }
+
+    @Override
+    public String getRevokedConsentStatus() {
+        return REJECTED;
+    }
+
+    @Override
+    public MultiValueMap<String, String> getValidStateTransitions() {
+        return new LinkedMultiValueMap<>(stateTransitions);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.customerinfo.CustomerInfoConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultCustomerInfoAccessConsentService extends BaseConsentService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> implements CustomerInfoConsentService {
+
+    private final String revokedStatus;
+
+    public DefaultCustomerInfoAccessConsentService(CustomerInfoConsentRepository repo) {
+        super(repo, IntentType.CUSTOMER_INFO_CONSENT::generateIntentId, CustomerInfoConsentStateModel.getInstance());
+        revokedStatus = CustomerInfoConsentStateModel.getInstance().getRevokedConsentStatus();
+    }
+
+    @Override
+    protected void addConsentSpecificAuthorisationData(CustomerInfoConsentEntity consent, CustomerInfoAuthoriseConsentArgs authoriseConsentArgs) {
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.account.OBReadData1;
+import uk.org.openbanking.datamodel.account.OBRisk2;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link DefaultCustomerInfoAccessConsentService}
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class DefaultCustomerInfoAccessConsentServiceTest extends BaseConsentServiceTest<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> {
+    private static final String API_CLIENT_ID = UUID.randomUUID().toString();
+
+    @Autowired
+    private DefaultCustomerInfoAccessConsentService customerInfoAccessConsentService;
+
+    @Override
+    protected BaseConsentService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> getConsentServiceToTest() {
+        return customerInfoAccessConsentService;
+    }
+
+    @Override
+    protected ConsentStateModel getConsentStateModel() {
+        return CustomerInfoConsentStateModel.getInstance();
+    }
+
+    @Override
+    protected CustomerInfoConsentEntity getValidConsentEntity() {
+        return createValidConsentEntity(API_CLIENT_ID);
+    }
+
+    @Override
+    protected CustomerInfoAuthoriseConsentArgs getAuthoriseConsentArgs(String consentId, String resourceOwnerId, String apiClientId) {
+        return new CustomerInfoAuthoriseConsentArgs(consentId, apiClientId, resourceOwnerId);
+    }
+
+    @Override
+    protected void validateConsentSpecificFields(CustomerInfoConsentEntity expected, CustomerInfoConsentEntity actual) {
+    }
+
+    @Override
+    protected void validateConsentSpecificAuthorisationFields(CustomerInfoConsentEntity authorisedConsent, CustomerInfoAuthoriseConsentArgs authorisationArgs) {
+    }
+
+    @Test
+    void deleteConsent() {
+        final CustomerInfoConsentEntity consentObj = getValidConsentEntity();
+
+        final CustomerInfoConsentEntity persistedConsent = consentService.createConsent(consentObj);
+
+        final String consentId = persistedConsent.getId();
+        final CustomerInfoAuthoriseConsentArgs authoriseConsentArgs = getAuthoriseConsentArgs(consentId, TEST_RESOURCE_OWNER, consentObj.getApiClientId());
+        consentService.authoriseConsent(authoriseConsentArgs);
+
+        consentService.deleteConsent(consentId, consentObj.getApiClientId());
+        final ConsentStoreException consentStoreException = Assertions.assertThrows(ConsentStoreException.class, () -> consentService.getConsent(consentId, consentObj.getApiClientId()));
+        assertThat(consentStoreException.getErrorType()).isEqualTo(ConsentStoreException.ErrorType.NOT_FOUND);
+    }
+
+    @Test
+    void testConsentCanBeReAuthenticated() {
+        final CustomerInfoConsentEntity consent = createValidConsentEntity(API_CLIENT_ID);
+        consent.setStatus(getConsentStateModel().getAuthorisedConsentStatus());
+        assertThat(consentService.canTransitionToAuthorisedState(consent)).isTrue();
+    }
+
+    public static CustomerInfoConsentEntity createValidConsentEntity(String apiClientId) {
+        final CustomerInfoConsentEntity customerInfoConsentEntity = new CustomerInfoConsentEntity();
+        customerInfoConsentEntity.setApiClientId(apiClientId);
+        customerInfoConsentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
+        customerInfoConsentEntity.setRequestVersion(OBVersion.v1_0);
+
+        final OBReadConsent1 obReadConsent = new OBReadConsent1();
+        obReadConsent.setData(new OBReadData1().permissions(List.of(OBExternalPermissions1Code.READCUSTOMERINFO))
+                .expirationDateTime(DateTime.now().plusDays(30)));
+        obReadConsent.setRisk(new OBRisk2());
+        customerInfoConsentEntity.setRequestObj(FRReadConsentConverter.toFRReadConsent(obReadConsent));
+
+        return customerInfoConsentEntity;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.decision.ConsentDecisionDeserialized;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.BaseConsentDecisionService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+public class CustomerInfoConsentDecisionService extends BaseConsentDecisionService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> {
+
+    public CustomerInfoConsentDecisionService(CustomerInfoConsentService customerInfoConsentService) {
+        super(IntentType.CUSTOMER_INFO_CONSENT, customerInfoConsentService);
+    }
+
+    @Override
+    protected CustomerInfoAuthoriseConsentArgs buildAuthoriseConsentArgs(String intentId, String apiClientId, String resourceOwnerId, ConsentDecisionDeserialized consentDecision) {
+        return new CustomerInfoAuthoriseConsentArgs(intentId, apiClientId, resourceOwnerId);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.CustomerInfoConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.BaseConsentDetailsService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.CustomerInfoService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import org.joda.time.LocalDate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class CustomerInfoConsentDetailsService extends BaseConsentDetailsService<CustomerInfoConsentEntity, CustomerInfoConsentDetails> {
+
+    private final CustomerInfoService customerInfoService;
+
+    public CustomerInfoConsentDetailsService(
+            ConsentService<CustomerInfoConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            CustomerInfoService customerInfoService
+    ) {
+        super(IntentType.CUSTOMER_INFO_CONSENT, CustomerInfoConsentDetails::new, consentService,
+                apiProviderConfiguration, apiClientService);
+        this.customerInfoService = customerInfoService;
+    }
+
+    @Override
+    protected void addIntentTypeSpecificData(
+            CustomerInfoConsentDetails consentDetails,
+            CustomerInfoConsentEntity consent,
+            ConsentClientDetailsRequest consentClientDetailsRequest
+    ) {
+        consentDetails.setPermissions(consent.getRequestObj().getData().getPermissions());
+        Optional<FRCustomerInfo> customerInfo = customerInfoService.getCustomerInformation(
+                consentClientDetailsRequest.getUser().getId()
+        );
+        if (customerInfo.isPresent()) {
+            consentDetails.setCustomerInfo(customerInfo.get());
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/CustomerInfoService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/CustomerInfoService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsResourceApiConfiguration;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.Opt;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.web.util.UriComponentsBuilder.fromHttpUrl;
+
+/**
+ * Service to request customer information operations to Test facility Bank (RS) resources api
+ */
+@Service
+@Slf4j
+public class CustomerInfoService {
+
+    private final RestTemplate restTemplate;
+    private final RsConfiguration rsConfiguration;
+    private final RsResourceApiConfiguration rsResourceApiConfiguration;
+
+    public CustomerInfoService(
+            RestTemplate restTemplate,
+            RsConfiguration rsConfiguration,
+            RsResourceApiConfiguration rsResourceApiConfiguration
+    ) {
+        this.restTemplate = restTemplate;
+        this.rsConfiguration = rsConfiguration;
+        this.rsResourceApiConfiguration = rsResourceApiConfiguration;
+    }
+
+    public Optional<FRCustomerInfo> getCustomerInformation(String userId) {
+        log.debug("Making a request to RS to retrieve customer information details with user Id: {}", userId);
+
+        ResponseEntity<FRCustomerInfo> entity = restTemplate.exchange(
+                getFindByUserIdOperationUri(userId),
+                GET,
+                null,
+                FRCustomerInfo.class
+        );
+        return Optional.ofNullable(entity.getBody());
+    }
+
+    private URI getFindByUserIdOperationUri(String userId) {
+        UriComponentsBuilder builder = fromHttpUrl(
+                rsConfiguration.getBaseUri() +
+                        rsResourceApiConfiguration.getCustomerInfo().get(
+                                RsResourceApiConfiguration.Operation.FIND_USER_BY_ID.toString()
+                        )
+        );
+        return builder.queryParam("userId", userId).build().encode().toUri();
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsApplicationConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsApplicationConfiguration.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -51,6 +52,8 @@ import com.nimbusds.jose.jwk.RSAKey;
 
 import uk.org.openbanking.jackson.DateTimeDeserializer;
 import uk.org.openbanking.jackson.DateTimeSerializer;
+import uk.org.openbanking.jackson.LocalDateDeserializer;
+import uk.org.openbanking.jackson.LocalDateSerializer;
 
 @Configuration
 public class RcsApplicationConfiguration {
@@ -93,6 +96,8 @@ public class RcsApplicationConfiguration {
             jacksonObjectMapperBuilder.dateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
             jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new DateTimeDeserializer());
             jacksonObjectMapperBuilder.serializerByType(DateTime.class, new DateTimeSerializer(DateTime.class));
+            jacksonObjectMapperBuilder.deserializerByType(LocalDate.class, new LocalDateDeserializer());
+            jacksonObjectMapperBuilder.serializerByType(LocalDate.class, new LocalDateSerializer(LocalDate.class));
         };
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsResourceApiConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RsResourceApiConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "rs.api.resource")
+@Data
+public class RsResourceApiConfiguration {
+
+    private Map<String, String> customerInfo = new LinkedCaseInsensitiveMap<>();
+
+    public enum Operation {
+        FIND_USER_BY_ID("findByUserId");
+        private final String operation;
+
+        Operation(String uriContext) {
+            this.operation = uriContext;
+        }
+
+        public static Operation fromValue(String value) {
+            for (Operation uriContext : Operation.values()) {
+                if (uriContext.operation.equals(value)) {
+                    return uriContext;
+                }
+            }
+            throw new IllegalArgumentException("No enum constant '" + value + "'");
+        }
+
+        public String toString() {
+            return operation;
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -79,7 +79,7 @@ consent:
   store:
     enabled:
       # Controls which intentTypes will use the new Consent Store (format: comma separated list)
-      intentTypes: ACCOUNT_ACCESS_CONSENT, PAYMENT_DOMESTIC_CONSENT, PAYMENT_DOMESTIC_SCHEDULED_CONSENT, PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, DOMESTIC_VRP_PAYMENT_CONSENT, PAYMENT_FILE_CONSENT
+      intentTypes: ACCOUNT_ACCESS_CONSENT, PAYMENT_DOMESTIC_CONSENT, PAYMENT_DOMESTIC_SCHEDULED_CONSENT, PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, DOMESTIC_VRP_PAYMENT_CONSENT, PAYMENT_FILE_CONSENT, CUSTOMER_INFO_CONSENT
 
 spring:
   data:
@@ -90,6 +90,10 @@ spring:
 # See: com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsBackofficeConfiguration
 rs:
   api:
+    resource:
+      customer-info:
+        # Context endpoing to find customer information by userId
+        findByUserId: /resources/customerinfo/findByUserId
     backoffice:
       uris:
         accounts:

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.decision.ConsentDecisionDeserialized;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.Constants;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Test for {@link CustomerInfoConsentDecisionService}
+ */
+
+@ExtendWith(MockitoExtension.class)
+public class CustomerInfoConsentDecisionServiceTest {
+    private static final String TEST_API_CLIENT_ID = UUID.randomUUID().toString();
+    private static final String TEST_RESOURCE_OWNER_ID = UUID.randomUUID().toString();
+
+    @Mock
+    private CustomerInfoConsentService customerInfoConsentService;
+
+    @InjectMocks
+    private CustomerInfoConsentDecisionService customerInfoConsentDecisionService;
+
+    @Test
+    public void testAuthoriseConsent() {
+        final String intentId = IntentType.ACCOUNT_ACCESS_CONSENT.generateIntentId();
+
+        final ConsentDecisionDeserialized consentDecision = createAuthoriseCustomerInfoConsentDecision();
+        customerInfoConsentDecisionService.authoriseConsent(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID, consentDecision);
+
+        verify(customerInfoConsentService).authoriseConsent(refEq(new CustomerInfoAuthoriseConsentArgs(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID)));
+        verifyNoMoreInteractions(customerInfoConsentService);
+    }
+
+    @Test
+    public void testSubmitCustomerInfoRejectDecision() {
+        final String intentId = IntentType.ACCOUNT_ACCESS_CONSENT.generateIntentId();
+
+        customerInfoConsentDecisionService.rejectConsent(intentId, TEST_API_CLIENT_ID, TEST_RESOURCE_OWNER_ID);
+
+        verify(customerInfoConsentService).rejectConsent(eq(intentId), eq(TEST_API_CLIENT_ID), eq(TEST_RESOURCE_OWNER_ID));
+        verifyNoMoreInteractions(customerInfoConsentService);
+    }
+
+    public static ConsentDecisionDeserialized createAuthoriseCustomerInfoConsentDecision() {
+        final ConsentDecisionDeserialized consentDecision = new ConsentDecisionDeserialized();
+        consentDecision.setDecision(Constants.ConsentDecisionStatus.AUTHORISED);
+        return consentDecision;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiControllerRcsConsentStoreTest.java
@@ -29,6 +29,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.*;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,16 +49,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.RedirectionAction;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.AccountsConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticScheduledPaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticStandingOrderConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.DomesticVrpPaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.FilePaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalPaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalScheduledPaymentConsentDetails;
-import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.InternationalStandingOrderConsentDetails;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorClient;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
@@ -166,7 +157,8 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
                 arguments(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, createInternationalScheduledPaymentConsentDetails(), InternationalScheduledPaymentConsentDetails.class),
                 arguments(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, createInternationalStandingOrderConsentDetails(), InternationalStandingOrderConsentDetails.class),
                 arguments(IntentType.PAYMENT_FILE_CONSENT, createFilePaymentConsentDetails(), FilePaymentConsentDetails.class),
-                arguments(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, createVrpConsentDetails(), DomesticVrpPaymentConsentDetails.class)
+                arguments(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, createVrpConsentDetails(), DomesticVrpPaymentConsentDetails.class),
+                arguments(IntentType.CUSTOMER_INFO_CONSENT, createCustomerInfoConsentDetails(), CustomerInfoConsentDetails.class)
         );
     }
 
@@ -177,9 +169,16 @@ public class ConsentDetailsApiControllerRcsConsentStoreTest {
         return accountsConsentDetails;
     }
 
-    @ParameterizedTest
+    private static CustomerInfoConsentDetails createCustomerInfoConsentDetails() {
+        final CustomerInfoConsentDetails customerInfoConsentDetails = new CustomerInfoConsentDetails();
+        customerInfoConsentDetails.setConsentId(IntentType.CUSTOMER_INFO_CONSENT.generateIntentId());
+        customerInfoConsentDetails.setLogo(TPP_LOGO);
+        return customerInfoConsentDetails;
+    }
+
+    @ParameterizedTest(name = "{0}")
     @MethodSource("validConsentDetailsArguments")
-    public <C extends ConsentDetails> void shouldGetDomesticPaymentConsentDetails(IntentType intentType, ConsentDetails testConsentDetails,
+    public <C extends ConsentDetails> void shouldGetParameterizedConsentDetails(IntentType intentType, ConsentDetails testConsentDetails,
                                                                                   Class<C> consentDetailsClass) throws Exception {
 
         Assumptions.assumeTrue(consentStoreEnabledIntentTypes.isIntentTypeSupported(intentType));

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsServiceTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.customerinfo;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRExternalPermissionsCode;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.details.CustomerInfoConsentDetails;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ApiClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.ConsentClientDetailsRequest;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.models.User;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services.ApiClientServiceClient;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.CustomerInfoService;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.account.AccountAccessConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.DefaultAccountAccessConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.CustomerInfoConsentStateModel;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.account.OBReadData1;
+import uk.org.openbanking.datamodel.account.OBRisk2;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.FRCustomerInfoTestHelper.aValidFRCustomerInfo;
+import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.DefaultCustomerInfoAccessConsentServiceTest.createValidConsentEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Test for {@link CustomerInfoConsentDetailsService}
+ */
+@ExtendWith(MockitoExtension.class)
+public class CustomerInfoConsentDetailsServiceTest {
+
+    private static final String TEST_API_PROVIDER = "Test Api Provider";
+
+    @Mock
+    private CustomerInfoConsentService customerInfoConsentService;
+
+    @Mock
+    private CustomerInfoService customerInfoService;
+
+    @Mock
+    private ApiClientServiceClient apiClientServiceClient;
+
+    @Mock
+    private ApiProviderConfiguration apiProviderConfiguration;
+
+    @InjectMocks
+    private CustomerInfoConsentDetailsService consentDetailsService;
+
+    private final User testUser;
+
+    private final ApiClient testApiClient;
+
+    private final Optional<FRCustomerInfo> optionalFRCustomerInfo;
+
+    public CustomerInfoConsentDetailsServiceTest() {
+        testUser = new User();
+        testUser.setId("test-user-1");
+        testUser.setUserName("testUser");
+
+        testApiClient = new ApiClient();
+        testApiClient.setId("acme-tpp-1");
+        testApiClient.setName("ACME Corp");
+
+        optionalFRCustomerInfo = Optional.ofNullable(aValidFRCustomerInfo(testUser.getId()));
+    }
+
+    @Test
+    void shouldCreateCustomerInfoDetails() throws ExceptionClient {
+        final String intentId = IntentType.CUSTOMER_INFO_CONSENT.generateIntentId();
+        final CustomerInfoConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+        consentEntity.setId(intentId);
+        shouldCreateCustomerInfoDetails(consentEntity);
+    }
+
+    @Test
+    void shouldCreateCustomerInfoDetailsReAuthenticateConsent() throws ExceptionClient {
+        final String intentId = IntentType.CUSTOMER_INFO_CONSENT.generateIntentId();
+        final CustomerInfoConsentEntity consentEntity = createValidConsentEntity(testApiClient.getId());
+        consentEntity.setId(intentId);
+        consentEntity.setStatus(CustomerInfoConsentStateModel.getInstance().getAuthorisedConsentStatus());
+
+        shouldCreateCustomerInfoDetails(consentEntity);
+    }
+    private void shouldCreateCustomerInfoDetails(CustomerInfoConsentEntity consentEntity) throws ExceptionClient {
+        final String intentId = consentEntity.getId();
+        given(apiClientServiceClient.getApiClient(eq(testApiClient.getId()))).willReturn(testApiClient);
+        given(customerInfoService.getCustomerInformation(testUser.getId())).willReturn(optionalFRCustomerInfo);
+        given(apiProviderConfiguration.getName()).willReturn(TEST_API_PROVIDER);
+        given(customerInfoConsentService.getConsent(intentId, testApiClient.getId())).willReturn(consentEntity);
+        given(customerInfoConsentService.canTransitionToAuthorisedState(eq(consentEntity))).willReturn(Boolean.TRUE);
+
+        final ConsentDetails consentDetails = consentDetailsService.getDetailsFromConsentStore(
+                new ConsentClientDetailsRequest(intentId, null, testUser, testApiClient.getId()));
+
+        assertThat(consentDetails).isInstanceOf(CustomerInfoConsentDetails.class);
+        CustomerInfoConsentDetails customerInfoConsentDetails = (CustomerInfoConsentDetails) consentDetails;
+        assertThat(customerInfoConsentDetails.getConsentId()).isEqualTo(intentId);
+        assertThat(customerInfoConsentDetails.getClientName()).isEqualTo(testApiClient.getName());
+        assertThat(customerInfoConsentDetails.getUsername()).isEqualTo(testUser.getUserName());
+        assertThat(customerInfoConsentDetails.getLogo()).isEqualTo(testApiClient.getLogoUri());
+        assertThat(customerInfoConsentDetails.getServiceProviderName()).isEqualTo(TEST_API_PROVIDER);
+        assertThat(customerInfoConsentDetails.getUserId()).isEqualTo(testUser.getId());
+        assertThat(customerInfoConsentDetails.getCustomerInfo()).isEqualTo(optionalFRCustomerInfo.get());
+        assertThat(customerInfoConsentDetails.getPermissions()).isEqualTo(List.of(FRExternalPermissionsCode.READCUSTOMERINFO));
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/CustomerInfoServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/CustomerInfoServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.RsResourceApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.FRCustomerInfoTestHelper.aValidFRCustomerInfo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * Unit test for {@link CustomerInfoService}
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+        classes = {
+                RsConfiguration.class,
+                RsResourceApiConfiguration.class,
+                CustomerInfoService.class,
+                RestTemplate.class,
+                MappingJackson2HttpMessageConverter.class
+        },
+        initializers = ConfigFileApplicationContextInitializer.class
+)
+@EnableConfigurationProperties(value = {RsResourceApiConfiguration.class})
+@ActiveProfiles("test")
+public class CustomerInfoServiceTest {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private RsConfiguration rsConfiguration;
+
+    @Autowired
+    private RsResourceApiConfiguration rsResourceApiConfiguration;
+
+    @Autowired
+    private CustomerInfoService customerInfoService;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter mappingJacksonHttpMessageConverter;
+
+    private MockRestServiceServer mockServer;
+    private String baseUri;
+
+    @BeforeEach
+    public void setup() {
+        baseUri = rsConfiguration.getBaseUri();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    @Test
+    void shouldReturnValidFRCustomerInfo() throws Exception {
+        // Given
+        String userId = UUID.randomUUID().toString();
+        FRCustomerInfo customerInfoResponseExpected = aValidFRCustomerInfo(userId);
+        String findByUserIdUriContext = rsResourceApiConfiguration.getCustomerInfo().get(
+                RsResourceApiConfiguration.Operation.FIND_USER_BY_ID.toString()
+        );
+
+        mockServer.expect(
+                        ExpectedCount.once(), requestTo(baseUri + findByUserIdUriContext + "?userId=" + userId)
+                )
+                .andExpect(method(GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(
+                                mappingJacksonHttpMessageConverter.getObjectMapper().writeValueAsString(customerInfoResponseExpected)
+                        )
+                );
+        // When
+        Optional<FRCustomerInfo> customerInfo = customerInfoService.getCustomerInformation(userId);
+        // Then
+        mockServer.verify();
+        assertThat(customerInfo.isPresent()).isTrue();
+        assertEquals(customerInfo.get(), customerInfoResponseExpected);
+    }
+
+    @Test
+    void shouldReturnCustomerInfoNotFound() {
+        // Given
+        String userId = UUID.randomUUID().toString();
+        String findByUserIdUriContext = rsResourceApiConfiguration.getCustomerInfo().get(
+                RsResourceApiConfiguration.Operation.FIND_USER_BY_ID.toString()
+        );
+
+        mockServer.expect(
+                        ExpectedCount.once(), requestTo(baseUri + findByUserIdUriContext + "?userId=" + userId)
+                )
+                .andExpect(method(GET))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+        // When
+        HttpClientErrorException exception = assertThrows(HttpClientErrorException.class, () -> customerInfoService.getCustomerInformation(userId));
+
+        // Then
+        mockServer.verify();
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/FRCustomerInfoTestHelper.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/FRCustomerInfoTestHelper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRAddressTypeCode;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfo;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomerInfoAddress;
+import org.joda.time.DateTime;
+
+import java.util.List;
+import java.util.UUID;
+
+public class FRCustomerInfoTestHelper {
+
+    public static FRCustomerInfo aValidFRCustomerInfo() {
+        return aValidFRCustomerInfo(UUID.randomUUID().toString());
+    }
+
+    public static FRCustomerInfo aValidFRCustomerInfo(String userId) {
+        return FRCustomerInfo.builder()
+                .userID(userId)
+                .userName("Joe.Doe")
+                .address(FRCustomerInfoTestHelper.aValidFRCustomerInfoAddress())
+                .birthdate(new DateTime().minusYears(19).toLocalDate())
+                .email("joe.doe@acme.com")
+                .familyName("Joe")
+                .givenName("Doe")
+                .initials("JD")
+                .title("Mr")
+                .partyId("party-Id")
+                .phoneNumber("+44 7777 777777").build();
+    }
+
+    public static FRCustomerInfo aValidFRCustomerInfo(String userId, String userName) {
+        return FRCustomerInfo.builder()
+                .userID(userId)
+                .userName(userName)
+                .address(FRCustomerInfoTestHelper.aValidFRCustomerInfoAddress())
+                .birthdate(new DateTime().minusYears(19).toLocalDate())
+                .email("joe.doe@acme.com")
+                .familyName("Joe")
+                .givenName("Doe")
+                .initials("JD")
+                .title("Mr")
+                .partyId("party-Id")
+                .phoneNumber("+44 7777 777777").build();
+    }
+
+    public static FRCustomerInfoAddress aValidFRCustomerInfoAddress() {
+        return FRCustomerInfoAddress.builder()
+                .streetAddress(List.of("999", "Letsbe Avenue", "Chelmsford", "Essex"))
+                .addressType(FRAddressTypeCode.RESIDENTIAL)
+                .country("UK")
+                .postalCode("ES12 3RR").build();
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsConfigurationPropertiesTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsConfigurationPropertiesTest.java
@@ -30,8 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit test for {@link RsConfiguration}
  */
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {RsConfiguration.class, RsBackofficeConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
-@EnableConfigurationProperties(value = RsBackofficeConfiguration.class)
+@ContextConfiguration(
+        classes = {RsConfiguration.class, RsBackofficeConfiguration.class, RsResourceApiConfiguration.class},
+        initializers = ConfigFileApplicationContextInitializer.class
+)
+@EnableConfigurationProperties(value = {RsBackofficeConfiguration.class, RsResourceApiConfiguration.class})
 @ActiveProfiles("test")
 public class RcsConfigurationPropertiesTest {
 
@@ -39,6 +42,8 @@ public class RcsConfigurationPropertiesTest {
     private RsConfiguration configurationProperties;
     @Autowired
     private RsBackofficeConfiguration rsBackofficeConfiguration;
+    @Autowired
+    private RsResourceApiConfiguration rsResourceApiConfiguration;
 
     @Test
     public void shouldHaveAllRCSProperties() {
@@ -54,5 +59,12 @@ public class RcsConfigurationPropertiesTest {
         assertThat(rsBackofficeConfiguration.getDomesticPayments().get(
                 RsBackofficeConfiguration.UriContexts.FIND_USER_BY_ID.toString())
         ).isEqualTo("/backoffice/domestic-payments/search/findByUserId");
+    }
+
+    @Test
+    public void shouldHaveAllRsResourceApiProperties() {
+        assertThat(rsResourceApiConfiguration.getCustomerInfo().get(
+                RsResourceApiConfiguration.Operation.FIND_USER_BY_ID.toString())
+        ).isEqualTo("/resources/customerinfo/findByUserId");
     }
 }


### PR DESCRIPTION
- Added support of customer info consent APIs
- Added customer info store client APIs
- Added customer info test coverage for all new APIs
- Enabled Customer info consent to be stored in mongo
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1069