### PR TITLE
1084: funds confirmation store API

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApi.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import io.swagger.annotations.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+
+import javax.validation.Valid;
+
+@Validated
+@Api(tags = {"v3.1.10"})
+@RequestMapping(value = "/consent/store/v3.1.10")
+public interface FundsConfirmationConsentApi {
+
+
+    @ApiOperation(value = "Create Funds Confirmation Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "FundsConfirmationConsent object representing the consent created",
+                    response = FundsConfirmationConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/funds-confirmation-consents",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<FundsConfirmationConsent> createConsent(@ApiParam(value = "Create Consent Request", required = true)
+                                                           @Valid
+                                                           @RequestBody CreateFundsConfirmationConsentRequest request);
+
+
+    @ApiOperation(value = "Get Funds Confirmation Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "FundsConfirmationConsent object representing the consent created",
+                    response = FundsConfirmationConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/funds-confirmation-consents/{consentId}",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
+    ResponseEntity<FundsConfirmationConsent> getConsent(@PathVariable(value = "consentId") String consentId,
+                                                        @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+    @ApiOperation(value = "Authorise Funds Confirmation Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "FundsConfirmationConsent object representing the consent created",
+                    response = FundsConfirmationConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/funds-confirmation-consents/{consentId}/authorise",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<FundsConfirmationConsent> authoriseConsent(@PathVariable(value = "consentId") String consentId,
+                                                              @ApiParam(value = "Authorise Consent Request", required = true)
+                                                              @Valid
+                                                              @RequestBody AuthoriseFundsConfirmationConsentRequest request);
+
+
+    @ApiOperation(value = "Reject Funds Confirmation Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "FundsConfirmationConsent object representing the consent created",
+                    response = FundsConfirmationConsent.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/funds-confirmation-consents/{consentId}/reject",
+            consumes = {"application/json; charset=utf-8"},
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<FundsConfirmationConsent> rejectConsent(@PathVariable(value = "consentId") String consentId,
+                                                           @ApiParam(value = "Reject Consent Request", required = true)
+                                                           @Valid
+                                                           @RequestBody RejectConsentRequest request);
+
+
+    @ApiOperation(value = "Delete Funds Confirmation Consent")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Delete successful"),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/funds-confirmation-consents/{consentId}",
+            method = RequestMethod.DELETE)
+    ResponseEntity<Void> deleteConsent(@PathVariable(value = "consentId") String consentId,
+                                       @RequestHeader(value = "x-api-client-id") String apiClientId);
+
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiController.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds.FundsConfirmationAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds.FundsConfirmationConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.Objects;
+
+@Controller
+public class FundsConfirmationConsentApiController implements FundsConfirmationConsentApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final FundsConfirmationConsentService consentService;
+
+    private final OBVersion obVersion;
+
+    @Autowired
+    public FundsConfirmationConsentApiController(FundsConfirmationConsentService consentService) {
+        this(consentService, OBVersion.v3_1_10);
+    }
+
+    public FundsConfirmationConsentApiController(FundsConfirmationConsentService consentService, OBVersion obVersion) {
+        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
+        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
+    }
+
+    @Override
+    public ResponseEntity<FundsConfirmationConsent> createConsent(CreateFundsConfirmationConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
+        final FundsConfirmationConsentEntity consentEntity = new FundsConfirmationConsentEntity();
+        consentEntity.setRequestObj(request.getConsentRequest());
+        consentEntity.setApiClientId(request.getApiClientId());
+        consentEntity.setRequestVersion(obVersion);
+        consentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
+
+        final FundsConfirmationConsentEntity persistedEntity = consentService.createConsent(consentEntity);
+        logger.info("Consent created with id: {}", persistedEntity.getId());
+
+        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<FundsConfirmationConsent> getConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
+    }
+
+    @Override
+    public ResponseEntity<FundsConfirmationConsent> authoriseConsent(String consentId, AuthoriseFundsConfirmationConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final FundsConfirmationAuthoriseConsentArgs authoriseArgs = new FundsConfirmationAuthoriseConsentArgs(consentId, request.getApiClientId(),
+                request.getResourceOwnerId());
+        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(authoriseArgs)));
+    }
+
+    @Override
+    public ResponseEntity<FundsConfirmationConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to deleteConsent - id: {}, apiClientId: {}", consentId, apiClientId);
+        consentService.deleteConsent(consentId, apiClientId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    private FundsConfirmationConsent convertEntityToDto(FundsConfirmationConsentEntity entity) {
+        final FundsConfirmationConsent dto = new FundsConfirmationConsent();
+        dto.setApiClientId(entity.getApiClientId());
+        dto.setId(entity.getId());
+        dto.setCreationDateTime(entity.getCreationDateTime());
+        dto.setStatus(entity.getStatus());
+        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
+        dto.setRequestVersion(entity.getRequestVersion());
+        dto.setRequestObj(entity.getRequestObj());
+        dto.setResourceOwnerId(entity.getResourceOwnerId());
+        return dto;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiControllerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds.FRFundsConfirmationConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.BaseControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.common.OBCashAccount3;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentData1;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Test for {@link FundsConfirmationConsentApiController}
+ */
+public class FundsConfirmationConsentApiControllerTest extends BaseControllerTest<FundsConfirmationConsent, CreateFundsConfirmationConsentRequest, AuthoriseFundsConfirmationConsentRequest> {
+
+
+    protected FundsConfirmationConsentApiControllerTest() {
+        super(FundsConfirmationConsent.class);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        apiBaseUrl = "http://localhost:" + port + "/consent/store/v3.1.10/" + getControllerEndpointName();
+    }
+
+    @Override
+    protected String getControllerEndpointName() {
+        return "funds-confirmation-consents";
+    }
+
+    @Override
+    protected CreateFundsConfirmationConsentRequest buildCreateConsentRequest(String apiClientId) {
+        final CreateFundsConfirmationConsentRequest createRequest = new CreateFundsConfirmationConsentRequest();
+        createRequest.setApiClientId(apiClientId);
+        final OBFundsConfirmationConsent1 fundsConfirmationConsent1 = new OBFundsConfirmationConsent1();
+        fundsConfirmationConsent1.setData(
+                new OBFundsConfirmationConsentData1()
+                        .expirationDateTime(DateTime.now().plusDays(30))
+                        .debtorAccount(
+                                new OBCashAccount3()
+                                        .schemeName("UK.OBIE.SortCodeAccountNumber")
+                                        .identification("40400422390112")
+                                        .name("Mrs B Smith")
+                        )
+        );
+        createRequest.setConsentRequest(FRFundsConfirmationConsentConverter.toFRFundsConfirmationConsent(fundsConfirmationConsent1));
+        return createRequest;
+    }
+
+    @Override
+    protected void validateCreateConsentAgainstCreateRequest(FundsConfirmationConsent consent, CreateFundsConfirmationConsentRequest createConsentRequest) {
+        FundsConfirmationConsentValidationHelpers.validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Override
+    protected AuthoriseFundsConfirmationConsentRequest buildAuthoriseConsentRequest(FundsConfirmationConsent consent, String resourceOwnerId) {
+        AuthoriseFundsConfirmationConsentRequest authoriseFundsConfirmationConsentRequest = new AuthoriseFundsConfirmationConsentRequest();
+        authoriseFundsConfirmationConsentRequest.setConsentId(consent.getId());
+        authoriseFundsConfirmationConsentRequest.setApiClientId(consent.getApiClientId());
+        authoriseFundsConfirmationConsentRequest.setResourceOwnerId(resourceOwnerId);
+        return authoriseFundsConfirmationConsentRequest;
+    }
+
+    @Override
+    protected void validateAuthorisedConsent(FundsConfirmationConsent authorisedConsent, AuthoriseFundsConfirmationConsentRequest authoriseConsentReq, FundsConfirmationConsent originalConsent) {
+        FundsConfirmationConsentValidationHelpers.validateAuthorisedConsent(authorisedConsent, authoriseConsentReq, originalConsent);
+    }
+
+    @Override
+    protected void validateRejectedConsent(FundsConfirmationConsent rejectedConsent, RejectConsentRequest rejectConsentRequest, FundsConfirmationConsent originalConsent) {
+        FundsConfirmationConsentValidationHelpers.validateRejectedConsent(rejectedConsent, rejectConsentRequest, originalConsent);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentValidationHelpers.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentValidationHelpers.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Helper methods for validating {@link FundsConfirmationConsent} objects as part of using the {@link FundsConfirmationConsentApi}
+ */
+public class FundsConfirmationConsentValidationHelpers {
+
+    public static void validateCreateConsentAgainstCreateRequest(FundsConfirmationConsent consent,
+                                                                 CreateFundsConfirmationConsentRequest createFundsConfirmationConsentRequest) {
+        assertThat(consent.getId()).isNotEmpty();
+        assertThat(consent.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION.toString());
+        assertThat(consent.getApiClientId()).isEqualTo(createFundsConfirmationConsentRequest.getApiClientId());
+        assertThat(consent.getRequestObj()).isEqualTo(createFundsConfirmationConsentRequest.getConsentRequest());
+        assertThat(consent.getRequestVersion()).isEqualTo(OBVersion.v3_1_10);
+        assertThat(consent.getResourceOwnerId()).isNull();
+        assertThat(consent.getCreationDateTime()).isLessThan(DateTime.now());
+        assertThat(consent.getStatusUpdateDateTime()).isEqualTo(consent.getCreationDateTime());
+    }
+
+    public static void validateAuthorisedConsent(FundsConfirmationConsent authorisedConsent, AuthoriseFundsConfirmationConsentRequest authoriseReq, FundsConfirmationConsent originalConsent) {
+        assertThat(authorisedConsent.getStatus()).isEqualTo(StatusEnum.AUTHORISED.toString());
+        assertThat(authorisedConsent.getResourceOwnerId()).isEqualTo(authoriseReq.getResourceOwnerId());
+        validateUpdatedConsentAgainstOriginal(authorisedConsent, originalConsent);
+    }
+
+    public static void validateRejectedConsent(FundsConfirmationConsent rejectedConsent, RejectConsentRequest rejectReq, FundsConfirmationConsent originalConsent) {
+        assertThat(rejectedConsent.getStatus()).isEqualTo(StatusEnum.REJECTED.toString());
+        assertThat(rejectedConsent.getResourceOwnerId()).isEqualTo(rejectReq.getResourceOwnerId());
+        validateUpdatedConsentAgainstOriginal(rejectedConsent, originalConsent);
+    }
+
+    /**
+     * Validates fields in an updatedConsent vs an original consent.
+     * <p>
+     * This checks that fields that should never change when a consent is updated do never change, and verifies that
+     * the statusUpdateDateTime increases vs the original.
+     */
+    public static void validateUpdatedConsentAgainstOriginal(FundsConfirmationConsent updatedConsent, FundsConfirmationConsent consent) {
+        assertThat(updatedConsent.getId()).isEqualTo(consent.getId());
+        assertThat(updatedConsent.getApiClientId()).isEqualTo(consent.getApiClientId());
+        assertThat(updatedConsent.getRequestObj()).isEqualTo(consent.getRequestObj());
+        assertThat(updatedConsent.getRequestVersion()).isEqualTo(consent.getRequestVersion());
+        assertThat(updatedConsent.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
+        assertThat(updatedConsent.getStatusUpdateDateTime()).isLessThanOrEqualTo(DateTime.now()).isGreaterThan(consent.getStatusUpdateDateTime());
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/FundsConfirmationConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/FundsConfirmationConsentStoreClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+
+/**
+ * Client for interacting with com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10.FundsConfirmationConsentApi
+ */
+public interface FundsConfirmationConsentStoreClient {
+    FundsConfirmationConsent createConsent(CreateFundsConfirmationConsentRequest createConsentRequest) throws ConsentStoreClientException;
+
+    FundsConfirmationConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+
+    FundsConfirmationConsent authoriseConsent(AuthoriseFundsConfirmationConsentRequest authoriseFundsConfirmationConsentRequest) throws ConsentStoreClientException;
+
+    FundsConfirmationConsent rejectConsent(RejectConsentRequest rejectFundsConfirmationConsentRequest) throws ConsentStoreClientException;
+
+    void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException;
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/RestFundsConfirmationConsentStoreClient.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/RestFundsConfirmationConsentStoreClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.funds.v3_1_10;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.BaseRestConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class RestFundsConfirmationConsentStoreClient extends BaseRestConsentStoreClient implements FundsConfirmationConsentStoreClient {
+
+    private final String consentServiceBaseUrl;
+
+    @Autowired
+    public RestFundsConfirmationConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration,
+                                                   RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+
+        this(consentStoreClientConfiguration, restTemplateBuilder, objectMapper, OBVersion.v3_1_10);
+    }
+
+    public RestFundsConfirmationConsentStoreClient(ConsentStoreClientConfiguration consentStoreClientConfiguration,
+                                                   RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper,
+                                                   OBVersion obVersion) {
+        super(restTemplateBuilder, objectMapper);
+        Objects.requireNonNull(consentStoreClientConfiguration, "consentStoreClientConfiguration must be provided");
+        this.consentServiceBaseUrl = consentStoreClientConfiguration.getBaseUri() + "/" + obVersion.getCanonicalName() + "/funds-confirmation-consents";
+    }
+
+
+    @Override
+    public FundsConfirmationConsent createConsent(CreateFundsConfirmationConsentRequest createConsentRequest) throws ConsentStoreClientException {
+        final HttpEntity<CreateFundsConfirmationConsentRequest> requestEntity = new HttpEntity<>(createConsentRequest, createHeaders(createConsentRequest.getApiClientId()));
+        return doRestCall(consentServiceBaseUrl, HttpMethod.POST, requestEntity, FundsConfirmationConsent.class);
+    }
+
+    @Override
+    public FundsConfirmationConsent getConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        return doRestCall(url, HttpMethod.GET, requestEntity, FundsConfirmationConsent.class);
+    }
+
+    @Override
+    public FundsConfirmationConsent authoriseConsent(AuthoriseFundsConfirmationConsentRequest authRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + authRequest.getConsentId() + "/authorise";
+        final HttpEntity<AuthoriseFundsConfirmationConsentRequest> requestEntity = new HttpEntity<>(authRequest, createHeaders(authRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, FundsConfirmationConsent.class);
+    }
+
+    @Override
+    public FundsConfirmationConsent rejectConsent(RejectConsentRequest rejectRequest) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + rejectRequest.getConsentId() + "/reject";
+        final HttpEntity<RejectConsentRequest> requestEntity = new HttpEntity<>(rejectRequest, createHeaders(rejectRequest.getApiClientId()));
+        return doRestCall(url, HttpMethod.POST, requestEntity, FundsConfirmationConsent.class);
+    }
+
+    @Override
+    public void deleteConsent(String consentId, String apiClientId) throws ConsentStoreClientException {
+        final String url = consentServiceBaseUrl + "/" + consentId;
+        final HttpEntity<Object> requestEntity = new HttpEntity<>(createHeaders(apiClientId));
+        doRestCall(url, HttpMethod.DELETE, requestEntity, Void.class);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/FundsConfirmationConsentStoreClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/client/funds/v3_1_10/FundsConfirmationConsentStoreClientTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.client.funds.v3_1_10;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds.FRFundsConfirmationConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.AuthoriseFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.CreateFundsConfirmationConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.openbanking.datamodel.common.OBCashAccount3;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentData1;
+
+import java.util.UUID;
+
+import static com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10.FundsConfirmationConsentValidationHelpers.*;
+import static com.forgerock.sapi.gateway.rcs.consent.store.client.TestConsentStoreClientConfigurationFactory.createConsentStoreClientConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Test for {@link FundsConfirmationConsentStoreClient}
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"rcs.consent.store.api.baseUri= 'ignored'"})
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+public class FundsConfirmationConsentStoreClientTest {
+
+    private static final String API_CLIENT_ID = UUID.randomUUID().toString();
+    private static final String RESOURCE_OWNER_ID = UUID.randomUUID().toString();
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private RestFundsConfirmationConsentStoreClient storeApiClient;
+
+    @BeforeEach
+    public void beforeEach() {
+        storeApiClient = new RestFundsConfirmationConsentStoreClient(createConsentStoreClientConfiguration(port), restTemplateBuilder, objectMapper);
+    }
+
+    @Test
+    void testCreateConsent() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final FundsConfirmationConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        validateCreateConsentAgainstCreateRequest(consent, createConsentRequest);
+    }
+
+    @Test
+    void failsToCreateConsentWhenFieldIsMissing() {
+        final CreateFundsConfirmationConsentRequest requestMissingConsentReqField = new CreateFundsConfirmationConsentRequest();
+        requestMissingConsentReqField.setApiClientId(API_CLIENT_ID);
+
+        final ConsentStoreClientException clientException = assertThrows(ConsentStoreClientException.class,
+                () -> storeApiClient.createConsent(requestMissingConsentReqField));
+        assertThat(clientException.getErrorType()).isEqualTo(ConsentStoreClientException.ErrorType.BAD_REQUEST);
+        assertThat(clientException.getObError1()).isNotNull();
+        assertThat(clientException.getObError1().getErrorCode()).isEqualTo("UK.OBIE.Field.Invalid");
+        assertThat(clientException.getObError1().getMessage()).isEqualTo("The field received is invalid. Reason 'must not be null'");
+        assertThat(clientException.getObError1().getPath()).isEqualTo("consentRequest");
+    }
+
+    @Test
+    void testAuthoriseConsent() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final FundsConfirmationConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        final AuthoriseFundsConfirmationConsentRequest authRequest = buildAuthoriseConsentRequest(consent);
+        final FundsConfirmationConsent authResponse = storeApiClient.authoriseConsent(authRequest);
+
+        validateAuthorisedConsent(authResponse, authRequest, consent);
+    }
+
+    @Test
+    void testRejectConsent() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final FundsConfirmationConsent consent = storeApiClient.createConsent(createConsentRequest);
+
+        final RejectConsentRequest rejectRequest = buildRejectRequest(consent);
+        final FundsConfirmationConsent rejectedConsent = storeApiClient.rejectConsent(rejectRequest);
+        validateRejectedConsent(rejectedConsent, rejectRequest, consent);
+    }
+
+    @Test
+    void testGetConsent() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final FundsConfirmationConsent consent = storeApiClient.createConsent(createConsentRequest);
+        final FundsConfirmationConsent getResponse = storeApiClient.getConsent(consent.getId(), consent.getApiClientId());
+        assertThat(getResponse).usingRecursiveComparison().isEqualTo(consent);
+    }
+
+    @Test
+    void testDeleteConsent() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = buildCreateConsentRequest();
+        final FundsConfirmationConsent consent = storeApiClient.createConsent(createConsentRequest);
+        storeApiClient.deleteConsent(consent.getId(), consent.getApiClientId());
+    }
+
+    private static CreateFundsConfirmationConsentRequest buildCreateConsentRequest() {
+        final CreateFundsConfirmationConsentRequest createConsentRequest = new CreateFundsConfirmationConsentRequest();
+        createConsentRequest.setApiClientId(API_CLIENT_ID);
+        final OBFundsConfirmationConsent1 fundsConfirmationConsent1 = new OBFundsConfirmationConsent1();
+        fundsConfirmationConsent1.setData(
+                new OBFundsConfirmationConsentData1()
+                        .expirationDateTime(DateTime.now().plusDays(30))
+                        .debtorAccount(
+                                new OBCashAccount3()
+                                        .schemeName("UK.OBIE.SortCodeAccountNumber")
+                                        .identification("40400422390112")
+                                        .name("Mrs B Smith")
+                        )
+        );
+        createConsentRequest.setConsentRequest(FRFundsConfirmationConsentConverter.toFRFundsConfirmationConsent(fundsConfirmationConsent1));
+        return createConsentRequest;
+    }
+
+    private static AuthoriseFundsConfirmationConsentRequest buildAuthoriseConsentRequest(FundsConfirmationConsent consent) {
+        final AuthoriseFundsConfirmationConsentRequest authRequest = new AuthoriseFundsConfirmationConsentRequest();
+        authRequest.setConsentId(consent.getId());
+        authRequest.setResourceOwnerId(RESOURCE_OWNER_ID);
+        authRequest.setApiClientId(consent.getApiClientId());
+        return authRequest;
+    }
+
+    private static RejectConsentRequest buildRejectRequest(FundsConfirmationConsent consent) {
+        final RejectConsentRequest rejectRequest = new RejectConsentRequest();
+        rejectRequest.setApiClientId(consent.getApiClientId());
+        rejectRequest.setConsentId(consent.getId());
+        rejectRequest.setResourceOwnerId(RESOURCE_OWNER_ID);
+        return rejectRequest;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/AuthoriseFundsConfirmationConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/AuthoriseFundsConfirmationConsentRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseAuthoriseConsentRequest;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Validated
+public class AuthoriseFundsConfirmationConsentRequest extends BaseAuthoriseConsentRequest {
+
+    @Override
+    public String toString() {
+        return "AuthoriseFundsConfirmationConsentRequest{" +
+                ", consentId='" + getConsentId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                '}';
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/CreateFundsConfirmationConsentRequest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/CreateFundsConfirmationConsentRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseCreateConsentRequest;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class CreateFundsConfirmationConsentRequest extends BaseCreateConsentRequest<FRFundsConfirmationConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/FundsConfirmationConsent.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/datamodel/funds/v3_1_10/FundsConfirmationConsent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.BaseConsent;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * OBIE Funds Confirmation Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/cbpii/funds-confirmation-consent.html
+ */
+@Validated
+public class FundsConfirmationConsent extends BaseConsent<FRFundsConfirmationConsent> {
+
+    @Override
+    public String toString() {
+        return "FundsConfirmationConsent{" +
+                ", id='" + getId() + '\'' +
+                ", requestObj=" + getRequestObj() +
+                ", requestVersion=" + getRequestVersion() +
+                ", status='" + getStatus() + '\'' +
+                ", apiClientId='" + getApiClientId() + '\'' +
+                ", resourceOwnerId='" + getResourceOwnerId() + '\'' +
+                ", creationDateTime=" + getCreationDateTime() +
+                ", statusUpdateDateTime=" + getStatusUpdateDateTime() +
+                '}';
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/funds/FundsConfirmationConsentEntity.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/entity/funds/FundsConfirmationConsentEntity.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.BaseConsentEntity;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * OBIE Funds Confirmation Consent: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/cbpii/funds-confirmation-consent.html
+ */
+@Document("FundsConfirmationConsent")
+@Validated
+public class FundsConfirmationConsentEntity extends BaseConsentEntity<FRFundsConfirmationConsent> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/funds/FundsConfirmationConsentRepository.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/mongo/funds/FundsConfirmationConsentRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.funds;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface FundsConfirmationConsentRepository extends MongoRepository<FundsConfirmationConsentEntity, String> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.funds.FundsConfirmationConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultFundsConfirmationAccessConsentService extends BaseConsentService<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> implements FundsConfirmationConsentService {
+
+    private final String revokedStatus;
+
+    public DefaultFundsConfirmationAccessConsentService(FundsConfirmationConsentRepository repo) {
+        super(repo, IntentType.FUNDS_CONFIRMATION_CONSENT::generateIntentId, FundsConfirmationConsentStateModel.getInstance());
+        revokedStatus = FundsConfirmationConsentStateModel.getInstance().getRevokedConsentStatus();
+    }
+
+    @Override
+    protected void addConsentSpecificAuthorisationData(FundsConfirmationConsentEntity consent, FundsConfirmationAuthoriseConsentArgs authoriseConsentArgs) {
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationAuthoriseConsentArgs.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationAuthoriseConsentArgs.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.AuthoriseConsentArgs;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class FundsConfirmationAuthoriseConsentArgs extends AuthoriseConsentArgs {
+
+    public FundsConfirmationAuthoriseConsentArgs(String consentId, String apiClientId, String resourceOwnerId) {
+        super(consentId, resourceOwnerId, apiClientId);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
+
+public interface FundsConfirmationConsentService extends ConsentService<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> {
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentStateModel.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentStateModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.util.List;
+
+/**
+ * State Model for Funds Confirmation Consents: https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/cbpii/funds-confirmation-consent.html#status-flow
+ *
+ * Funds Confirmation Consent are long-lived, and support re-authentication.
+ *
+ * Note: When a Consent is revoked (consent was previously authorised), it goes to rejected state. In previous versions of the
+ * OBIE API, there was a specific revoked state.
+ */
+public class FundsConfirmationConsentStateModel implements ConsentStateModel {
+
+    public static final String AWAITING_AUTHORISATION = OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString();
+    public static final String AUTHORISED = OBExternalRequestStatus1Code.AUTHORISED.toString();
+    public static final String REJECTED = OBExternalRequestStatus1Code.REJECTED.toString();
+
+    private static final FundsConfirmationConsentStateModel INSTANCE = new FundsConfirmationConsentStateModel();
+
+    public static FundsConfirmationConsentStateModel getInstance() {
+        return INSTANCE;
+    }
+
+    private final MultiValueMap<String, String> stateTransitions;
+
+
+    private FundsConfirmationConsentStateModel() {
+        stateTransitions = new LinkedMultiValueMap<>();
+        stateTransitions.addAll(AWAITING_AUTHORISATION, List.of(AUTHORISED, REJECTED));
+        stateTransitions.addAll(AUTHORISED, List.of(AUTHORISED, REJECTED)); // Authorised has a self link as consent Re-Authentication is supported
+    }
+
+    @Override
+    public String getInitialConsentStatus() {
+        return AWAITING_AUTHORISATION;
+    }
+
+    @Override
+    public String getAuthorisedConsentStatus() {
+        return AUTHORISED;
+    }
+
+    @Override
+    public String getRejectedConsentStatus() {
+        return REJECTED;
+    }
+
+    @Override
+    public String getRevokedConsentStatus() {
+        return REJECTED;
+    }
+
+    @Override
+    public MultiValueMap<String, String> getValidStateTransitions() {
+        return new LinkedMultiValueMap<>(stateTransitions);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentServiceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds.FRFundsConfirmationConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentServiceTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.account.OBReadData1;
+import uk.org.openbanking.datamodel.common.OBCashAccount3;
+import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentData1;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Test for {@link DefaultFundsConfirmationAccessConsentService}
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class DefaultFundsConfirmationAccessConsentServiceTest extends BaseConsentServiceTest<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> {
+
+    private static final String API_CLIENT_ID = UUID.randomUUID().toString();
+
+    @Autowired
+    private DefaultFundsConfirmationAccessConsentService fundsConfirmationAccessConsentService;
+
+    @Override
+    protected BaseConsentService<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> getConsentServiceToTest() {
+        return fundsConfirmationAccessConsentService;
+    }
+
+    @Override
+    protected ConsentStateModel getConsentStateModel() {
+        return FundsConfirmationConsentStateModel.getInstance();
+    }
+
+    @Override
+    protected FundsConfirmationConsentEntity getValidConsentEntity() {
+        return createValidConsentEntity(API_CLIENT_ID);
+    }
+
+    @Override
+    protected FundsConfirmationAuthoriseConsentArgs getAuthoriseConsentArgs(String consentId, String resourceOwnerId, String apiClientId) {
+        return new FundsConfirmationAuthoriseConsentArgs(consentId, apiClientId, resourceOwnerId);
+    }
+
+    @Override
+    protected void validateConsentSpecificFields(FundsConfirmationConsentEntity expected, FundsConfirmationConsentEntity actual) {
+
+    }
+
+    @Override
+    protected void validateConsentSpecificAuthorisationFields(FundsConfirmationConsentEntity authorisedConsent, FundsConfirmationAuthoriseConsentArgs authorisationArgs) {
+
+    }
+
+    public static FundsConfirmationConsentEntity createValidConsentEntity(String apiClientId) {
+        final FundsConfirmationConsentEntity fundsConfirmationConsentEntity = new FundsConfirmationConsentEntity();
+        fundsConfirmationConsentEntity.setApiClientId(apiClientId);
+        fundsConfirmationConsentEntity.setStatus(OBExternalRequestStatus1Code.AWAITINGAUTHORISATION.toString());
+        fundsConfirmationConsentEntity.setRequestVersion(OBVersion.v3_1_10);
+        final OBFundsConfirmationConsent1 fundsConfirmationConsent1 = new OBFundsConfirmationConsent1();
+        fundsConfirmationConsent1.setData(
+                new OBFundsConfirmationConsentData1()
+                        .expirationDateTime(DateTime.now().plusDays(30))
+                        .debtorAccount(
+                                new OBCashAccount3()
+                                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                                .identification("40400422390112")
+                                .name("Mrs B Smith")
+                        )
+        );
+        fundsConfirmationConsentEntity.setRequestObj(FRFundsConfirmationConsentConverter.toFRFundsConfirmationConsent(fundsConfirmationConsent1));
+        return fundsConfirmationConsentEntity;
+    }
+}


### PR DESCRIPTION
- Added funds confirmation consent store API, services and  and test coverage
- Added funds confirmation consent store client and test coverage
- Added funds confirmation consent, entity, dto, mongo repositories, sevices and test coverage

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1084