### PR TITLE
1102: prepare release 2.0.1 with helm chart version aligned with pom versions

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 2.0.0
-appVersion: 2.0.0
+version: 2.0.1
+appVersion: 2.0.1


### PR DESCRIPTION
- Upgrade helm chart to 2.0.1

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1102