### PR TITLE
1092: Checking that duplicate requests using the same idempotency key have the same request body

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreConfiguration.java
@@ -16,6 +16,7 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.repo;
 
 import java.util.EnumSet;
+import java.util.List;
 
 import javax.annotation.PostConstruct;
 
@@ -25,11 +26,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.MongoRepoPackageMarker;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+import com.forgerock.sapi.gateway.uk.common.shared.spring.converter.DateToUTCDateTimeConverter;
 
 @Configuration
 @ComponentScan(basePackageClasses = ConsentStoreConfiguration.class)
@@ -53,5 +57,20 @@ public class ConsentStoreConfiguration {
     @Bean
     public EnumSet<IntentType> getEnabledIntentTypes() {
         return enabledIntentTypes;
+    }
+
+    /**
+     * Create MongoCustomConversions instance with our custom data type converters.
+     * <p>
+     * {@link DateToUTCDateTimeConverter} is installed to convert Date objects in Mongo documents to joda DateTime
+     * objects specifying UTC timezone.
+     * Without this converter, the joda default converter will use the system's timezone instead which leads to issues
+     * when calling equals() on OB data-model objects due to TZ mismatch with data received via the REST API (which is always UTC).
+     */
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        final List<Converter> customConverters = List.of(new DateToUTCDateTimeConverter());
+        logger.info("Installing custom converters for Mongo: {}", customConverters);
+        return new MongoCustomConversions(customConverters);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/BasePaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/BasePaymentConsentService.java
@@ -21,6 +21,8 @@ import java.util.function.Supplier;
 import org.joda.time.DateTime;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.BasePaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException.ErrorType;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
@@ -46,7 +48,13 @@ public class BasePaymentConsentService<T extends BasePaymentConsentEntity<?>, A 
     @Override
     public T createConsent(T consent) {
         final Optional<T> consentMatchingIdempotencyData = getRepo().findByIdempotencyData(consent.getApiClientId(), consent.getIdempotencyKey(), DateTime.now());
-        // TODO ifPresent then test that requests match
+        if (consentMatchingIdempotencyData.isPresent()) {
+            final T existingConsent = consentMatchingIdempotencyData.get();
+            if (!existingConsent.getRequestObj().equals(consent.getRequestObj())) {
+                throw new ConsentStoreException(ErrorType.IDEMPOTENCY_ERROR, existingConsent.getId(),
+                        "The provided Idempotency Key: '" + consent.getIdempotencyKey() + "' header matched a previous request but the request body has been changed.");
+            }
+        }
         return consentMatchingIdempotencyData.orElseGet(() -> super.createConsent(consent));
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/TestApp.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/TestApp.java
@@ -15,10 +15,20 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo;
 
+import javax.annotation.PostConstruct;
+
+import org.joda.time.DateTimeZone;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @Import(ConsentStoreConfiguration.class)
 public class TestApp {
+
+    @PostConstruct
+    void postConstruct() {
+        // This is needed to make data generated in the unit tests UTC, which makes equality checking easier as Mongo will return data in UTC (and DateTime.equals using different timezones is false)
+        DateTimeZone.setDefault(DateTimeZone.UTC);
+    }
+
 }


### PR DESCRIPTION
Improving idempotent request handling to raise an error if the request body has been changed.

Configuring DateToUTCDateTimeConverter to ensure that data retrieved from Mongo comes back as UTC, otherwise equality checks fail as incoming data from the REST API is always UTC.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1092