### PR TITLE
1082: Renaming ConsentRepoConfiguration to CloudClientConfiguration

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/templates/deployment.yaml
@@ -70,11 +70,11 @@ spec:
               secretKeyRef:
                 name: openig-secrets-env
                 key: MONGODB_CONSENT_PASSWORD
-          - name: CONSENT_REPO_URI
+          - name: CLOUD_CLIENT_BASE_URI
             valueFrom:
               configMapKeyRef:
                 name: deployment-config
-                key: CONSENT_REPO_URI
+                key: GATEWAY_DATA_REPO_URI
           - name: RS_API_URI
             valueFrom:
               configMapKeyRef:

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/CloudClientConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/CloudClientConfiguration.java
@@ -17,19 +17,19 @@ package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration;
 
 import lombok.Data;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import java.util.Map;
 
-@Configuration
-@ConfigurationProperties(prefix = "consent.repo")
-@Data
-public class ConsentRepoConfiguration {
+import javax.annotation.PostConstruct;
 
-    @Value("${consent.repo.uri}")
+@Configuration
+@ConfigurationProperties(prefix = "cloud.client")
+@Data
+public class CloudClientConfiguration {
+
     private String baseUri;
 
     /*
@@ -42,7 +42,17 @@ public class ConsentRepoConfiguration {
     private Map<String, String> contextsApiClient = new LinkedCaseInsensitiveMap<>();
     private Map<String, String> contextsUser = new LinkedCaseInsensitiveMap<>();
 
-    public String getConsentRepoBaseUri() {
-        return baseUri;
+    @PostConstruct
+    private void validateConfig() {
+        if (baseUri == null || baseUri.isBlank()) {
+            throw new IllegalStateException("Required configuration: cloud.client.baseUri is missing");
+        }
+        if (contextsApiClient.isEmpty()) {
+            throw new IllegalStateException("Required configuration: cloud.client.contextsApiClient map is missing");
+        }
+        if (contextsUser.isEmpty()) {
+            throw new IllegalStateException("Required configuration: cloud.client.contextsUser map is missing");
+        }
     }
+
 }

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/ApiClientServiceClient.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/ApiClientServiceClient.java
@@ -16,7 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.Constants;
-import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.ConsentRepoConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.CloudClientConfiguration;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorClient;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
@@ -38,11 +38,11 @@ import static org.springframework.http.HttpMethod.GET;
 public class ApiClientServiceClient {
 
     private final RestTemplate restTemplate;
-    private final ConsentRepoConfiguration consentRepoConfiguration;
+    private final CloudClientConfiguration cloudClientConfiguration;
 
-    public ApiClientServiceClient(RestTemplate restTemplate, ConsentRepoConfiguration consentRepoConfiguration) {
+    public ApiClientServiceClient(RestTemplate restTemplate, CloudClientConfiguration cloudClientConfiguration) {
         this.restTemplate = restTemplate;
-        this.consentRepoConfiguration = consentRepoConfiguration;
+        this.cloudClientConfiguration = cloudClientConfiguration;
     }
 
     public ApiClient getApiClient(String apiClientId) throws ExceptionClient {
@@ -62,9 +62,9 @@ public class ApiClientServiceClient {
     }
 
     private ApiClient request(String apiClientId) throws ExceptionClient {
-        String apiClientURL = consentRepoConfiguration.getConsentRepoBaseUri() +
+        String apiClientURL = cloudClientConfiguration.getBaseUri() +
                 UrlContext.replaceParameterContextValue(
-                        consentRepoConfiguration.getContextsApiClient().get(GET.name()),
+                        cloudClientConfiguration.getContextsApiClient().get(GET.name()),
                         Constants.URLParameters.CLIENT_ID,
                         apiClientId
                 );

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/UserServiceClient.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/UserServiceClient.java
@@ -16,7 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.Constants;
-import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.ConsentRepoConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.CloudClientConfiguration;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorClient;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.exceptions.ExceptionClient;
@@ -38,11 +38,11 @@ import static org.springframework.http.HttpMethod.GET;
 public class UserServiceClient {
 
     private final RestTemplate restTemplate;
-    private final ConsentRepoConfiguration consentRepoConfiguration;
+    private final CloudClientConfiguration cloudClientConfiguration;
 
-    public UserServiceClient(RestTemplate restTemplate, ConsentRepoConfiguration consentRepoConfiguration) {
+    public UserServiceClient(RestTemplate restTemplate, CloudClientConfiguration cloudClientConfiguration) {
         this.restTemplate = restTemplate;
-        this.consentRepoConfiguration = consentRepoConfiguration;
+        this.cloudClientConfiguration = cloudClientConfiguration;
     }
 
     public User getUser(String userId) throws ExceptionClient {
@@ -62,9 +62,9 @@ public class UserServiceClient {
     }
 
     private User request(String userId) throws ExceptionClient {
-        String userURL = consentRepoConfiguration.getConsentRepoBaseUri() +
+        String userURL = cloudClientConfiguration.getBaseUri() +
                 UrlContext.replaceParameterContextValue(
-                        consentRepoConfiguration.getContextsUser().get(GET.name()),
+                        cloudClientConfiguration.getContextsUser().get(GET.name()),
                         Constants.URLParameters.USER_ID,
                         userId
                 );

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/CloudClientConfigurationTest.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/configuration/CloudClientConfigurationTest.java
@@ -16,6 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.TestApplicationClient;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,13 +31,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 
 /**
- * Unit test for {@link ConsentRepoConfiguration}
+ * Unit test for {@link CloudClientConfiguration}
  */
-@ContextConfiguration(classes = {ConsentRepoConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
-@EnableConfigurationProperties(value = ConsentRepoConfiguration.class)
+@ContextConfiguration(classes = {CloudClientConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
+@EnableConfigurationProperties(value = CloudClientConfiguration.class)
 @ActiveProfiles("test")
 @SpringBootTest(classes = TestApplicationClient.class, webEnvironment = MOCK)
-public class ConsentRepoConfigurationTest {
+public class CloudClientConfigurationTest {
 
     // values to get the proper context from the http verb that match with key mapping in the context, case-insensitive.
     private static final String GET = "GeT";
@@ -46,33 +47,33 @@ public class ConsentRepoConfigurationTest {
     @MockBean // mandatory to satisfied dependency for beans definitions
     private RestTemplate restTemplate;
     @Autowired
-    private ConsentRepoConfiguration consentRepoConfiguration;
+    private CloudClientConfiguration cloudClientConfiguration;
 
     @Test
     public void shouldConfigureIgBaseUri(){
-        assertThat(consentRepoConfiguration.getConsentRepoBaseUri()).isEqualTo("http://ig:80");
+        assertThat(cloudClientConfiguration.getBaseUri()).isEqualTo("http://ig:80");
     }
 
     @Test
     public void shouldHaveAllPropertiesSet() {
-        assertThat(consentRepoConfiguration.getConsentRepoBaseUri()).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsApiClient()).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsUser()).isNotNull();
+        assertThat(cloudClientConfiguration.getBaseUri()).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsApiClient()).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsUser()).isNotNull();
     }
 
     @Test
     public void shouldHaveApiClientContextVerbProperties() {
-        assertThat(consentRepoConfiguration.getContextsApiClient().get(GET)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsApiClient().get(PUT)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsApiClient().get(PATCH)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsApiClient().get(DELETE)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsApiClient().get(GET)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsApiClient().get(PUT)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsApiClient().get(PATCH)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsApiClient().get(DELETE)).isNotNull();
     }
 
     @Test
     public void shouldHaveUserContextVerbProperties() {
-        assertThat(consentRepoConfiguration.getContextsUser().get(GET)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsUser().get(PUT)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsUser().get(PATCH)).isNotNull();
-        assertThat(consentRepoConfiguration.getContextsUser().get(DELETE)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsUser().get(GET)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsUser().get(PUT)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsUser().get(PATCH)).isNotNull();
+        assertThat(cloudClientConfiguration.getContextsUser().get(DELETE)).isNotNull();
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/BaseServiceClientTest.java
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/cloud/client/services/BaseServiceClientTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.services;
 
-import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.ConsentRepoConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.CloudClientConfiguration;
 import com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.utils.url.UrlContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +30,7 @@ import org.springframework.web.client.RestTemplate;
 @ExtendWith(MockitoExtension.class)
 public class BaseServiceClientTest {
     @Mock
-    protected ConsentRepoConfiguration configurationProperties;
+    protected CloudClientConfiguration configurationProperties;
 
     @Mock
     protected RestTemplate restTemplate;

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
-consent:
-  repo:
-    uri: http://ig:80
+cloud:
+  client:
+    baseUri: http://ig:80
     contexts_api_client:
       get: /repo/apiclients/@ClientId@
       put: /repo/apiclients/@ClientId@

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -4,11 +4,11 @@
 # The following section is a template of the mandatory configuration that needs to be supplied in order to start the
 # application, this config is deployment specific.
 #
-# Consent Repo Configuration
-#consent:
-#  repo:
-#    # Connection string to the Consent Repo base URI
-#    uri:
+# Cloud Client API settings
+#cloud:
+#  client:
+#    # Connection string to connect to the Cloud Client API
+#    baseUri:
 #
 # Resource Server Configuration
 #rs:
@@ -51,11 +51,10 @@ api:
     # Name used in ConsentDetails, this gets displayed in the Consent UI
     name: Test Bank
 
-# Configuration for calling the Consent Repository
-# See: com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.ConsentRepoConfiguration
-consent:
-  # IDM Consent Repo
-  repo:
+# Configuration for calling the Cloud Data repository
+# com.forgerock.sapi.gateway.ob.uk.rcs.cloud.client.configuration.CloudClientConfiguration
+cloud:
+  client:
     # Context to build the URI to make a request against the repository endpoint to obtain the client object by clientId
     contexts_api_client:
       get: /repo/apiclients/@ClientId@
@@ -69,10 +68,11 @@ consent:
       patch: /repo/users/@UserId@
       delete: /repo/users/@UserId@
 
-  # RCS Consent Store config
+# RCS Consent Store config
+consent:
   store:
     enabled:
-      # Controls which intentTypes will use the new Consent Store (format: comma separated list)
+      # Controls which intentTypes are supported
       intentTypes: ACCOUNT_ACCESS_CONSENT, PAYMENT_DOMESTIC_CONSENT, PAYMENT_DOMESTIC_SCHEDULED_CONSENT, PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, DOMESTIC_VRP_PAYMENT_CONSENT, PAYMENT_FILE_CONSENT, CUSTOMER_INFO_CONSENT, PAYMENT_INTERNATIONAL_CONSENT, PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, FUNDS_CONFIRMATION_CONSENT
 
 spring:

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/resources/application-test.yml
@@ -4,9 +4,9 @@ rs:
   api:
     uri: http://localhost:8080
 
-consent:
-  repo:
-    uri: http://ig:80
+cloud:
+  client:
+    baseUri: http://ig:80
 
 rcs:
   consent:


### PR DESCRIPTION
CloudClientConfiguration is responsible for configuring the rcs-cloud-client module.

Renamed Spring config properties to use the `cloud.client` prefix

Updated helm chart to set the `cloud.client.baseUri` property to `GATEWAY_DATA_REPO_URI` from the configmap

https://github.com/SecureApiGateway/SecureApiGateway/issues/1082