### PR TITLE
1131: Improving error message when the user does not own the debtorAccount specified in the consent

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
@@ -23,6 +23,7 @@ public class ConsentStoreException extends RuntimeException {
         BAD_REQUEST,
         INVALID_STATE_TRANSITION,
         INVALID_CONSENT_DECISION,
+        INVALID_DEBTOR_ACCOUNT,
         CONSENT_REAUTHENTICATION_NOT_SUPPORTED,
         IDEMPOTENCY_ERROR
     }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/ConsentDetailsApiController.java
@@ -121,13 +121,17 @@ public class ConsentDetailsApiController implements ConsentDetailsApi {
                 errorType = ErrorType.ACCESS_DENIED;
                 errorMessage = "Consent Re-Authentication not supported for this type of consent";
             }
+            case INVALID_DEBTOR_ACCOUNT -> {
+                errorType = ErrorType.ACCESS_DENIED;
+                errorMessage = "User is not permissioned to make a payment from the debtorAccount specified";
+            }
             default -> {
                 errorType = ErrorType.INTERNAL_SERVER_ERROR;
                 errorMessage = "Server Error";
             }
         }
         return new InvalidConsentException(consentRequestJws, errorType, OBRIErrorType.REQUEST_BINDING_FAILED,
-                errorMessage, apiClientId, intentId);
+                                           errorMessage, apiClientId, intentId);
     }
 
     private ConsentClientDetailsRequest buildConsentClientRequest(SignedJWT signedJWT) throws ExceptionClient {

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
@@ -82,7 +82,7 @@ public class FundsConfirmationConsentDetailsService extends BaseConsentDetailsSe
                             "no account found for userId: {}, name:{}, identification: {}, schemeName: {}",
                     consentDetails.getConsentId(), consentDetails.getUserId(), debtorAccount.getName(),
                     debtorAccount.getIdentification(), debtorAccount.getSchemeName());
-            throw new ConsentStoreException(ConsentStoreException.ErrorType.NOT_FOUND, consentDetails.getConsentId(), "DebtorAccount not found for user");
+            throw new ConsentStoreException(ConsentStoreException.ErrorType.INVALID_DEBTOR_ACCOUNT, consentDetails.getConsentId(), "DebtorAccount not found for user");
         }
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsService.java
@@ -77,7 +77,7 @@ public abstract class BasePaymentConsentDetailsService<T extends BasePaymentCons
                                 "no account found for userId: {}, name:{}, identification: {}, schemeName: {}",
                         consentDetails.getConsentId(), consentDetails.getUserId(), debtorAccount.getName(),
                         debtorAccount.getIdentification(), debtorAccount.getSchemeName());
-                throw new ConsentStoreException(ErrorType.NOT_FOUND, consentDetails.getConsentId(), "DebtorAccount not found for user");
+                throw new ConsentStoreException(ErrorType.INVALID_DEBTOR_ACCOUNT, consentDetails.getConsentId(), "DebtorAccount not found for user");
             }
 
         } else {

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsServiceTest.java
@@ -42,6 +42,7 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.server.client.rs.AccountService;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConfiguration;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException.ErrorType;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds.FundsConfirmationConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds.FundsConfirmationConsentStateModel;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
@@ -127,7 +128,7 @@ public class FundsConfirmationConsentDetailsServiceTest {
         ConsentStoreException exception = assertThrows(ConsentStoreException.class, () -> testCreateFundsConfirmationConsentDetails(consentEntity));
 
         assertThat(exception).isNotNull();
-        assertThat(exception.getErrorType()).isEqualTo(ConsentStoreException.ErrorType.NOT_FOUND);
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_DEBTOR_ACCOUNT);
         assertThat(exception.getMessage()).contains("DebtorAccount not found for user");
     }
 


### PR DESCRIPTION
Adding ErrorType.INVALID_DEBTOR_ACCOUNT error code for this case. Updating the details controller to handle this error and produce a suitable error redirect_uri.

Example redirect_uri:
```
https://postman-echo.com/get#error=access_denied&state=10d260bf-a7d9-444a-92d9-7b7a5f088208&error_description=%20User%20is%20not%20permissioned%20to%20make%20a%20payment%20from%20the%20debtorAccount%20specified&error_uri=https://tools.ietf.org/html/rfc6749%23section-4.1.2.1
```

https://github.com/SecureApiGateway/SecureApiGateway/issues/1131