### PR TITLE
863: Installing FapiInteractionIdFilter in order to trace requests through the system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>2.1.0</uk.bom.version>
+        <uk.bom.version>2.1.1-SNAPSHOT</uk.bom.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>
 

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -40,6 +40,7 @@
         <gcrRepo>sbat-gcr-develop</gcrRepo>
         <!-- property to run individualy the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
     </properties>
 
     <organization>
@@ -131,6 +132,16 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <version>${logback.contrib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <version>${logback.contrib.version}</version>
         </dependency>
         <!-- ForgeRock Test dependencies -->
         <dependency>

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsApplicationConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/configuration/RcsApplicationConfiguration.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.jwt.RcsJwtSigner;
+import com.forgerock.sapi.gateway.uk.common.shared.spring.web.filter.FapiInteractionIdFilter;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
@@ -114,4 +115,14 @@ public class RcsApplicationConfiguration {
         final JWSSigner signer = new RSASSASigner((RSAKey) jwk);
         return new RcsJwtSigner(signingKeyId, JWSAlgorithm.parse(signingAlgorithm), signer);
     }
+
+    /**
+     * Installs the {@link FapiInteractionIdFilter}, this filter adds the x-fapi-interaction-id header value to the
+     * logging context.
+     */
+    @Bean
+    FapiInteractionIdFilter fapInteractionIdFilter() {
+        return new FapiInteractionIdFilter();
+    }
+
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/logback.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/resources/logback-test.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+


### PR DESCRIPTION
FapiInteractionIdFilter stores the x-fapi-interaction-id in the MDC log context

Updating logging configuration to use a JSON log format, which automatically adds the MDC data to the log message. Logging is now consistent with IG.

Adding logback dependencies to support JSON logging.

https://github.com/SecureApiGateway/SecureApiGateway/issues/863