### PR TITLE
Prepare release 2.2.0

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 2.1.0
-appVersion: 2.1.0
+version: 2.2.0
+appVersion: 2.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>secure-api-gateway-ob-uk-rcs</name>
     <description>A UK Open Banking Remote Consent Service for the Secure API Gateway</description>
@@ -41,7 +41,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>2.1.1-SNAPSHOT</uk.bom.version>
+        <uk.bom.version>2.2.0</uk.bom.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>
 

--- a/secure-api-gateway-ob-uk-rcs-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs-consent-store</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>secure-api-gateway-ob-uk-rcs-consent-store-api</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <legal.path.header>../../legal/LICENSE-HEADER.txt</legal.path.header>

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-client/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs-consent-store</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>secure-api-gateway-ob-uk-rcs-consent-store-client</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <legal.path.header>../../legal/LICENSE-HEADER.txt</legal.path.header>

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-datamodel/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs-consent-store</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>secure-api-gateway-ob-uk-rcs-consent-store-datamodel</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <legal.path.header>../../legal/LICENSE-HEADER.txt</legal.path.header>

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs-consent-store</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>secure-api-gateway-ob-uk-rcs-consent-store-repo</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <legal.path.header>../../legal/LICENSE-HEADER.txt</legal.path.header>

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Updated helm chart to 2.2.0
- bumped commons 2.2.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1182