### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,7 @@ env:
   GIT_SHA_SHORT: $(echo ${{ github.sha }} | cut -c1-7)
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
     name: Check PR
     steps:
@@ -50,12 +50,6 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
 
-  build:
-    runs-on: ubuntu-latest
-    name: Build Image
-    needs: check
-    steps:
-
       - name: Build Changes
         run: |
           make verify
@@ -81,11 +75,6 @@ jobs:
     name: Test Image
     needs: build
     steps:
-      - name: Check Code Coverage (not in use)
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
-
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,23 +50,23 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
 
-      - name: 'run functional tests'
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v ARGO_VALUES_PREFIX=remoteConsentServer -v SERVICE_NAME=remote-consent-server'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,25 +12,27 @@ env:
   GIT_SHA_SHORT: $(echo ${{ github.sha }} | cut -c1-7)
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
-    name: Check master integrity
+    name: Check PR
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get version
+      - name: Get Version
         id: get_version
         run: |
           echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
           echo "MAVEN_SERVER_ID=maven.forgerock.org-community" >> $GITHUB_ENV
 
-      - name: Set up snapshot forgerock maven repository
+      - name: Set Up Snapshot Forgerock Maven Repository
         if: contains( env.VERSION, 'SNAPSHOT')
         run: |
           echo "MAVEN_SERVER_ID=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
 
-      - uses: actions/setup-java@v3
-        name: set java and maven cache
+      # set java and cache
+      - name: Set Java and Maven Cache
+        uses: actions/setup-java@v3
+        id: set_java_maven
         with:
           distribution: 'adopt'
           java-version: '14'
@@ -40,32 +42,47 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - name: test
-        run: |
-          make verify
-
-      - name: Deploy artifact package
-        run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
-        env:
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-
-      - uses: google-github-actions/auth@v2
+      - name: Auth GCP 
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
 
-      - run: |
+      - name: Test Changes
+        run: |
+          make verify
+
+      - name: Check Code Coverage (not in use)
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build Image
+    steps:
+      - name: Deploy Artifact Package
+        run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
+        env:
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+
+      - name: Auth Docker 
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
+          docker tag eu.gcr.io/${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push eu.gcr.io/${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
 
+  test:
+    runs-on: ubuntu-latest
+    name: Test Image
+    steps:
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
@@ -73,9 +90,5 @@ jobs:
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          TRIGGER_NAME: github-actions-trigger-rs
+          TRIGGER_NAME: github-actions-trigger-rcs
         id: run-pipeline
-
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -62,6 +62,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Image
+    needs: check
     steps:
       - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
@@ -82,6 +83,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test Image
+    needs: build
     steps:
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -50,20 +50,16 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
 
-      - name: Test Changes
-        run: |
-          make verify
-
-      - name: Check Code Coverage (not in use)
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
-
   build:
     runs-on: ubuntu-latest
     name: Build Image
     needs: check
     steps:
+
+      - name: Build Changes
+        run: |
+          make verify
+      
       - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
         env:
@@ -85,6 +81,11 @@ jobs:
     name: Test Image
     needs: build
     steps:
+      - name: Check Code Coverage (not in use)
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+
       - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,27 +13,27 @@ env:
   PR_NUMBER: pr-${{ github.event.number }}
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
-    name: Check PR integrity
+    name: Check PR
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get version
+      - name: Get Version
         id: get_version
         run: |
           echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
           echo "MAVEN_SERVER_ID=maven.forgerock.org-community" >> $GITHUB_ENV
 
-      - name: Set up snapshot forgerock maven repository
+      - name: Set Up Snapshot Forgerock Maven Repository
         if: contains( env.VERSION, 'SNAPSHOT')
         run: |
           echo "MAVEN_SERVER_ID=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
 
       # set java and cache
-      - uses: actions/setup-java@v3
+      - name: Set Java and Maven Cache
+        uses: actions/setup-java@v3
         id: set_java_maven
-        name: set java and maven cache
         with:
           distribution: 'adopt'
           java-version: '14'
@@ -43,46 +43,57 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - uses: google-github-actions/auth@v2
+      - name: Auth GCP 
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
 
-      - name: template helm
+      - name: Template Helm
         run: |
           helm template $HELM_DIRECTORY/$SERVICE_NAME
 
       - name: Check Copyright
         run: mvn license:check
 
-      - name: test
+      - name: Test Changes
         run: |
           make verify
 
-      - name: Deploy artifact package
+      - name: Check Code Coverage (not in use)
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build Image
+    steps:
+      - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
         env:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
-      - run: |
+      - name: Auth Docker 
+        run: |
           gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.PR_NUMBER }}
 
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
-
-      - name: Create lowercase Github Username
+  test:
+    runs-on: ubuntu-latest
+    name: Test Image
+    steps:
+      - name: Create Lowercase Github Username
         id: toLowerCase
         run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}          
 
-      - name: 'Deploy Service'
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=remoteConsentServer -v SERVICE_NAME=remote-consent-server -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Template Helm
+        run: |
+          helm template $HELM_DIRECTORY/$SERVICE_NAME
+
+      - name: Check Copyright
+        run: mvn license:check
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build Image
+    needs: check
+    steps:
+      - uses: actions/checkout@v3
+
       - name: Get Version
         id: get_version
         run: |
@@ -50,20 +64,6 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
-
-      - name: Template Helm
-        run: |
-          helm template $HELM_DIRECTORY/$SERVICE_NAME
-
-      - name: Check Copyright
-        run: mvn license:check
-
-  build:
-    runs-on: ubuntu-latest
-    name: Build Image
-    needs: check
-    steps:
-
       - name: Test Changes
         run: |
           make verify
@@ -87,10 +87,6 @@ jobs:
     name: Test Image
     needs: build
     steps:
-      - name: Check Code Coverage (not in use)
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
 
       - name: Create Lowercase Github Username
         id: toLowerCase

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,12 +43,12 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
       - name: template helm
         run: |
@@ -68,7 +68,7 @@ jobs:
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
 
       - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,20 +58,16 @@ jobs:
       - name: Check Copyright
         run: mvn license:check
 
-      - name: Test Changes
-        run: |
-          make verify
-
-      - name: Check Code Coverage (not in use)
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
-
   build:
     runs-on: ubuntu-latest
     name: Build Image
     needs: check
     steps:
+
+      - name: Test Changes
+        run: |
+          make verify
+
       - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
         env:
@@ -91,6 +87,11 @@ jobs:
     name: Test Image
     needs: build
     steps:
+      - name: Check Code Coverage (not in use)
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+
       - name: Create Lowercase Github Username
         id: toLowerCase
         run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}          

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build Image
+    needs: check
     steps:
       - name: Deploy Artifact Package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
@@ -88,6 +89,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test Image
+    needs: build
     steps:
       - name: Create Lowercase Github Username
         id: toLowerCase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       SERVICE_NAME: securebanking-openbanking-uk-rcs
     secrets:
       GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
-      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_helm:
     name: Call publish helm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
       SERVICE_NAME: securebanking-openbanking-uk-rcs
     secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
+      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
       GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
 
   release_helm:

--- a/secure-api-gateway-ob-uk-rcs-server/docker/docker-compose-git.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/docker/docker-compose-git.yml
@@ -3,7 +3,7 @@ services:
 
   securebanking-config-server:
     container_name: securebanking-config-server
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-spring-config-server
     environment:
       - CONFIG_GIT_IGNORE_LOCAL_SSH=true
       - GIT_CONFIG_SSH_KEY=${GIT_SSH_KEY}
@@ -14,7 +14,7 @@ services:
 
   rcs-service:
     container_name: rcs-service
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rcs
     ports:
       - 8080:8080
       - 9095:9095
@@ -35,7 +35,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rs
     ports:
       - 8081:8080
       - 9095:9095

--- a/secure-api-gateway-ob-uk-rcs-server/docker/docker-compose.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   securebanking-config-server:
     container_name: securebanking-config-server
     hostname: securebanking-config-server
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-spring-config-server
     environment:
       - SPRING_PROFILES_ACTIVE=native
       - CONFIG_SERVER_SEARCH_LOCATIONS=file:///home/config
@@ -15,7 +15,7 @@ services:
 
   rcs-service:
     container_name: rcs-service
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rcs
     ports:
       - 8080:8080
       - 9095:9095
@@ -34,7 +34,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rs
     ports:
       - 8081:8080
       - 9096:9096

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -210,7 +210,7 @@
                 <configuration>
                     <dockerfile>docker/Dockerfile</dockerfile>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/${gcrRepo}/securebanking/securebanking-openbanking-uk-rcs</repository>
+                    <repository>europe-west4-docker.pkg.dev/${gcrRepo}/securebanking/securebanking-openbanking-uk-rcs</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -210,7 +210,7 @@
                 <configuration>
                     <dockerfile>docker/Dockerfile</dockerfile>
                     <skipPush>false</skipPush>
-                    <repository>europe-west4-docker.pkg.dev/${gcrRepo}/securebanking/securebanking-openbanking-uk-rcs</repository>
+                    <repository>europe-west4-docker.pkg.dev/${gcrRepo}/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rcs</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202