### PR TITLE
1223: Updating to bouncy castle version 1.77

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -118,11 +118,12 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Switching to jdk18on (JDK 1.8+) flavour of bouncy castle libraries as version 1.77 is only available for this artifactId.

See PR: https://github.com/SecureApiGateway/secure-api-gateway-parent/pull/87

https://github.com/SecureApiGateway/SecureApiGateway/issues/1223