### PR TITLE
1235: Configure server.max-http-request-header-size

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/resources/application.yml
@@ -34,7 +34,7 @@
 #
 
 server:
-  max-http-header-size: 16KB
+  max-http-request-header-size: 16KB
 
 logging:
   level:


### PR DESCRIPTION
server.max-http-header-size has been deprecated and has been replaced with server.max-http-request-header-size, updating our application config to use the new property

https://github.com/SecureApiGateway/SecureApiGateway/issues/1235