### PR TITLE
1251: Prepare release 2.3.0

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rcs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service
 description: RCS service Helm chart for Kubernetes
 type: application
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.3.0
+appVersion: 2.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <properties>
-        <uk.bom.version>2.3.0-SNAPSHOT</uk.bom.version>
+        <uk.bom.version>2.3.0</uk.bom.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>
 


### PR DESCRIPTION
Bump parent and bom to 2.3.0

Bump helm charts to 2.3.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1251