### PR TITLE
1251: Fix release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
       release_version_number: ${{ inputs.release_version_number }}
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
       SERVICE_NAME: securebanking-openbanking-uk-rcs
+      GAR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
     secrets:
       GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
-      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_helm:
     name: Call publish helm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name := securebanking-openbanking-uk-rcs
-repo := sbat-gcr-develop
+repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 tag  := $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 helm_repo := forgerock-helm/secure-api-gateway/securebanking-openbanking-uk-rcs/
 

--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -37,7 +37,7 @@
     <properties>
 
         <tag>latest</tag>
-        <gcrRepo>sbat-gcr-develop</gcrRepo>
+        <gcrRepo>europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact</gcrRepo>
         <!-- property to run individualy the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
         <logback.contrib.version>0.1.5</logback.contrib.version>
@@ -227,7 +227,7 @@
                 <configuration>
                     <dockerfile>docker/Dockerfile</dockerfile>
                     <skipPush>false</skipPush>
-                    <repository>europe-west4-docker.pkg.dev/${gcrRepo}/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rcs</repository>
+                    <repository>${gcrRepo}/securebanking/securebanking-openbanking-uk-rcs</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>


### PR DESCRIPTION
We were only passing the sbat-gcr-develop as ${gcrRepo} and overwriting it with sbat-gcr-release when doing a release, but the value of GAR_RELEASE_REPO contains the full GAR url of europe-west4-docker.pkg.dev/sbat-gcr-release/sapig-docker-artifact

So modifying the existing values so that the end value is valid

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1251