### PR TITLE
1267: Removing mockito-inline and gson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
 
     <properties>
         <uk.bom.version>2.3.0</uk.bom.version>
-        <mockito-inline.version>5.2.0</mockito-inline.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-cloud-client/pom.xml
@@ -102,10 +102,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
         <!-- External Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -115,12 +111,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito-inline.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
These dependencies are no longer being used.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1267