### PR TITLE
1274: Combine release prepare & release prepare no maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
     uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-prepare.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
+      require_maven: true
     secrets:
       GPG_PRIVATE_KEY_BOT: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
       GPG_KEY_PASSPHRASE_BOT: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}


### PR DESCRIPTION
Add in boolean for stating wherever to run maven commands or not in release prepare
Call only release prepare

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1274