### PR TITLE
1479: Remove unused name param from findByAccountIdentifiers query

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
@@ -72,7 +72,7 @@ public class FundsConfirmationConsentDetailsService extends BaseConsentDetailsSe
         final FRAccountIdentifier debtorAccount = consentDetails.getDebtorAccount();
         Objects.requireNonNull(debtorAccount, "The debtor account must be not null to check funds availability.");
         FRAccountWithBalance accountWithBalance = accountService.getAccountWithBalanceByIdentifiers(
-                consentDetails.getUserId(), debtorAccount.getName(), debtorAccount.getIdentification(), debtorAccount.getSchemeName());
+                consentDetails.getUserId(), debtorAccount.getIdentification(), debtorAccount.getSchemeName());
 
         if (Objects.nonNull(accountWithBalance)) {
             debtorAccount.setAccountId(accountWithBalance.getAccount().getAccountId());

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsService.java
@@ -67,7 +67,7 @@ public abstract class BasePaymentConsentDetailsService<T extends BasePaymentCons
         final FRAccountIdentifier debtorAccount = consentDetails.getDebtorAccount();
         if (Objects.nonNull(debtorAccount)) {
             FRAccountWithBalance accountWithBalance = accountService.getAccountWithBalanceByIdentifiers(
-                    consentDetails.getUserId(), debtorAccount.getName(), debtorAccount.getIdentification(), debtorAccount.getSchemeName());
+                    consentDetails.getUserId(), debtorAccount.getIdentification(), debtorAccount.getSchemeName());
 
             if (Objects.nonNull(accountWithBalance)) {
                 debtorAccount.setAccountId(accountWithBalance.getAccount().getAccountId());

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/AccountService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/client/rs/AccountService.java
@@ -89,7 +89,7 @@ public class AccountService extends BaseRsClient {
         return entity.getBody();
     }
 
-    public FRAccountWithBalance getAccountWithBalanceByIdentifiers(String userID, String name, String identification, String schemeName) {
+    public FRAccountWithBalance getAccountWithBalanceByIdentifiers(String userID, String identification, String schemeName) {
         // This is necessary as auth server always uses lowercase user id
         String lowercaseUserId = userID.toLowerCase();
         log.debug("Searching for accounts with balance for user ID: {}", lowercaseUserId);
@@ -102,7 +102,6 @@ public class AccountService extends BaseRsClient {
         );
 
         builder.queryParam("userId", lowercaseUserId);
-        builder.queryParam("name", name);
         builder.queryParam("identification", identification);
         builder.queryParam("schemeName", schemeName);
 
@@ -111,30 +110,4 @@ public class AccountService extends BaseRsClient {
         return entity.getBody();
     }
 
-    public FRAccountWithBalance getAccountIdentifier(String userID, String name, String identification, String schemeName) {
-        // This is necessary as auth server always uses lowercase user id
-        String lowercaseUserId = userID.toLowerCase();
-        log.debug("Searching for accounts by identifiers user {}, name {}, identification {}, schemeName {}",
-                lowercaseUserId,
-                name,
-                identification,
-                schemeName
-        );
-
-        UriComponentsBuilder builder = fromHttpUrl(
-                rsConfiguration.getBaseUri() +
-                        rsBackofficeConfiguration.getAccounts().get(
-                                RsBackofficeConfiguration.UriContexts.FIND_BY_ACCOUNT_IDENTIFIERS.toString()
-                        )
-        );
-
-        builder.queryParam("userId", lowercaseUserId);
-        builder.queryParam("name", name);
-        builder.queryParam("identification", identification);
-        builder.queryParam("schemeName", schemeName);
-
-        URI uri = builder.build().encode().toUri();
-        ResponseEntity<FRAccountWithBalance> entity = restTemplate.exchange(uri, GET, createRequestEntity(), FRAccountWithBalance.class);
-        return entity.getBody();
-    }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsServiceTest.java
@@ -160,10 +160,8 @@ public class FundsConfirmationConsentDetailsServiceTest {
     }
 
     private void mockAccountService(String userId, FRAccountWithBalance willReturn) {
-        given(accountService.getAccountWithBalanceByIdentifiers(
-                        eq(userId), eq(accountIdentifier.getName()),
-                        eq(accountIdentifier.getIdentification()), eq(accountIdentifier.getSchemeName())
-                )
+        given(accountService.getAccountWithBalanceByIdentifiers(eq(userId), eq(accountIdentifier.getIdentification()),
+                eq(accountIdentifier.getSchemeName()))
         ).willReturn(willReturn);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/BasePaymentConsentDetailsServiceTest.java
@@ -129,7 +129,7 @@ public class BasePaymentConsentDetailsServiceTest {
     }
 
     protected void mockAccountServiceGetByIdentifiersResponse(OBWriteDomestic2DataInitiationDebtorAccount debtorAccount, FRAccountWithBalance accountWithBalance) {
-        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()), eq(debtorAccount.getName()),
-                eq(debtorAccount.getIdentification()), eq(debtorAccount.getSchemeName()))).willReturn(accountWithBalance);
+        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()), eq(debtorAccount.getIdentification()),
+                eq(debtorAccount.getSchemeName()))).willReturn(accountWithBalance);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsServiceTest.java
@@ -94,7 +94,7 @@ class DomesticScheduledPaymentConsentDetailsServiceTest extends BasePaymentConse
         final OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = new OBWriteDomestic2DataInitiationDebtorAccount().name("Test Account").identification("account-id-123").schemeName("accountId");
         mockApiClientServiceResponse();
         final FRAccountWithBalance accountWithBalance = FRAccountWithBalanceTestDataFactory.aValidFRAccountWithBalance();
-        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()), eq(debtorAccount.getName()),
+        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()),
                 eq(debtorAccount.getIdentification()), eq(debtorAccount.getSchemeName()))).willReturn(accountWithBalance);
         mockApiProviderConfigurationGetName();
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsServiceTest.java
@@ -92,7 +92,7 @@ class DomesticStandingOrderConsentDetailsServiceTest extends BasePaymentConsentD
         final OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = new OBWriteDomestic2DataInitiationDebtorAccount().name("Test Account").identification("account-id-123").schemeName("accountId");
         mockApiClientServiceResponse();
         final FRAccountWithBalance accountWithBalance = FRAccountWithBalanceTestDataFactory.aValidFRAccountWithBalance();
-        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()), eq(debtorAccount.getName()),
+        given(accountService.getAccountWithBalanceByIdentifiers(eq(testUser.getId()),
                 eq(debtorAccount.getIdentification()), eq(debtorAccount.getSchemeName()))).willReturn(accountWithBalance);
         mockApiProviderConfigurationGetName();
 


### PR DESCRIPTION
Latest RS backoffice API has removed the name param and made the userId param mandatory. Currently, the RCS always supplies the userId, cleaning up the code to stop sending the name param (which would be ignored).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1479