### PR TITLE
1481: Build V4 Images

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - '**/README.md'
       - '_infra/helm/**'
-env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   run_pr-template:
@@ -17,6 +15,6 @@ jobs:
     uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-merge.yml@main
     secrets: inherit
     with:
-      componentBranch: $BRANCH_NAME
+      componentBranch: ${{ github.head_ref || github.ref_name }}
       componentName: secure-api-gateway-ob-uk-rcs
       dockerTag: $(echo ${{ github.sha }} | cut -c1-7)


### PR DESCRIPTION
 Another way of passing in the branch name, don't set a global env var as didn't work in using the calling workflow in CI repo

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1481
