### PR TITLE
1440: Allow Consent API controllers to be configured for specific OB versions

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/BaseDomesticPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/BaseDomesticPaymentConsentApiController.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.AuthorisePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.CreateDomesticPaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic.DomesticPaymentConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+
+/**
+ * Base implementation of {@link DomesticPaymentConsentApi} containing the logic that is common across versions.
+ * The {@link OBVersion} can be plugged in via the constructor.
+ * <p>
+ * Version specific controller implementations should extend this class and specify the following annotations:
+ * {@link org.springframework.stereotype.Controller}, {@link org.springframework.web.bind.annotation.RequestMapping}
+ * and {@link io.swagger.annotations.Api}.
+ */
+public class BaseDomesticPaymentConsentApiController implements DomesticPaymentConsentApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected final DomesticPaymentConsentService consentService;
+    protected final Supplier<DateTime> idempotencyKeyExpirationSupplier;
+    protected final OBVersion obVersion;
+
+    public BaseDomesticPaymentConsentApiController(DomesticPaymentConsentService consentService,
+                                                   Supplier<DateTime> idempotencyKeyExpirationSupplier,
+                                                   OBVersion obVersion) {
+        this.consentService = requireNonNull(consentService, "consentService must be provided");
+        this.idempotencyKeyExpirationSupplier = requireNonNull(idempotencyKeyExpirationSupplier, "idempotencyKeyExpirationSupplier must be provided");
+        this.obVersion = requireNonNull(obVersion, "obVersion must be provided");
+    }
+
+    @Override
+    public ResponseEntity<DomesticPaymentConsent> createConsent(CreateDomesticPaymentConsentRequest request) {
+        logger.info("Attempting to createConsent: {}", request);
+        final DomesticPaymentConsentEntity domesticPaymentConsent = new DomesticPaymentConsentEntity();
+        domesticPaymentConsent.setRequestVersion(obVersion);
+        domesticPaymentConsent.setApiClientId(request.getApiClientId());
+        domesticPaymentConsent.setRequestObj(request.getConsentRequest());
+        domesticPaymentConsent.setStatus(OBPaymentConsentStatus.AWAITINGAUTHORISATION.toString());
+        domesticPaymentConsent.setCharges(request.getCharges());
+        domesticPaymentConsent.setIdempotencyKey(request.getIdempotencyKey());
+        domesticPaymentConsent.setIdempotencyKeyExpiration(idempotencyKeyExpirationSupplier.get());
+        final DomesticPaymentConsentEntity persistedEntity = consentService.createConsent(domesticPaymentConsent);
+        logger.info("Consent created with id: {}", persistedEntity.getId());
+
+        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<DomesticPaymentConsent> getConsent(String consentId, String apiClientId) {
+        logger.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
+        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
+    }
+
+    @Override
+    public ResponseEntity<DomesticPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
+        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
+        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
+                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
+
+        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
+    }
+
+    @Override
+    public ResponseEntity<DomesticPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
+        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
+    }
+
+    @Override
+    public ResponseEntity<DomesticPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
+        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
+        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
+    }
+
+    private DomesticPaymentConsent convertEntityToDto(DomesticPaymentConsentEntity entity) {
+        final DomesticPaymentConsent dto = new DomesticPaymentConsent();
+        dto.setId(entity.getId());
+        dto.setStatus(entity.getStatus());
+        dto.setRequestObj(entity.getRequestObj());
+        dto.setRequestVersion(entity.getRequestVersion());
+        dto.setApiClientId(entity.getApiClientId());
+        dto.setResourceOwnerId(entity.getResourceOwnerId());
+        dto.setAuthorisedDebtorAccountId(entity.getAuthorisedDebtorAccountId());
+        dto.setIdempotencyKey(entity.getIdempotencyKey());
+        dto.setIdempotencyKeyExpiration(entity.getIdempotencyKeyExpiration());
+        dto.setCharges(entity.getCharges());
+        dto.setCreationDateTime(entity.getCreationDateTime());
+        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
+        return dto;
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/DomesticPaymentConsentApi.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/DomesticPaymentConsentApi.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic.v3_1_10;
+package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic;
 
 import jakarta.validation.Valid;
 
@@ -31,7 +31,6 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePay
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.CreateDomesticPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
 
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
@@ -39,8 +38,6 @@ import io.swagger.annotations.ApiResponses;
 import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 @Validated
-@Api(tags = {"v3.1.10"})
-@RequestMapping(value = "/consent/store/v3.1.10")
 public interface DomesticPaymentConsentApi {
 
     @ApiOperation(value = "Create Domestic Payment Consent")

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
@@ -15,118 +15,31 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic.v3_1_10;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
-import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.AuthorisePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.CreateDomesticPaymentConsentRequest;
-import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticPaymentConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic.BaseDomesticPaymentConsentApiController;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic.DomesticPaymentConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
-import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import io.swagger.annotations.Api;
 
 /**
  * Implementation of DomesticPaymentConsentApi for OBIE version 3.1.10
- *
- * Note: the obVersion field is pluggable, so if there are no changes to the OBIE schema in later versions, then
- * these controllers can extend this and configure the
  */
 @Controller
-public class DomesticPaymentConsentApiController implements DomesticPaymentConsentApi {
-
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
-    private final DomesticPaymentConsentService consentService;
-
-    private final Supplier<DateTime> idempotencyKeyExpirationSupplier;
-
-    private final OBVersion obVersion;
+@Api(tags = {"v3.1.10"})
+@RequestMapping(value = "/consent/store/v3.1.10")
+public class DomesticPaymentConsentApiController extends BaseDomesticPaymentConsentApiController {
 
     @Autowired
     public DomesticPaymentConsentApiController(DomesticPaymentConsentService consentService,
-                                              Supplier<DateTime> idempotencyKeyExpirationSupplier) {
-        this(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
+                                               Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+        super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 
-    public DomesticPaymentConsentApiController(DomesticPaymentConsentService consentService,
-                                               Supplier<DateTime> idempotencyKeyExpirationSupplier,
-                                               OBVersion obVersion) {
-        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
-        this.idempotencyKeyExpirationSupplier = Objects.requireNonNull(idempotencyKeyExpirationSupplier, "idempotencyKeyExpirationSupplier must be provided");
-        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
-    }
-
-    @Override
-    public ResponseEntity<DomesticPaymentConsent> createConsent(CreateDomesticPaymentConsentRequest request) {
-        logger.info("Attempting to createConsent: {}", request);
-        final DomesticPaymentConsentEntity domesticPaymentConsent = new DomesticPaymentConsentEntity();
-        domesticPaymentConsent.setRequestVersion(obVersion);
-        domesticPaymentConsent.setApiClientId(request.getApiClientId());
-        domesticPaymentConsent.setRequestObj(request.getConsentRequest());
-        domesticPaymentConsent.setStatus(OBPaymentConsentStatus.AWAITINGAUTHORISATION.toString());
-        domesticPaymentConsent.setCharges(request.getCharges());
-        domesticPaymentConsent.setIdempotencyKey(request.getIdempotencyKey());
-        domesticPaymentConsent.setIdempotencyKeyExpiration(idempotencyKeyExpirationSupplier.get());
-        final DomesticPaymentConsentEntity persistedEntity = consentService.createConsent(domesticPaymentConsent);
-        logger.info("Consent created with id: {}", persistedEntity.getId());
-
-        return new ResponseEntity<>(convertEntityToDto(persistedEntity), HttpStatus.CREATED);
-    }
-
-    @Override
-    public ResponseEntity<DomesticPaymentConsent> getConsent(String consentId, String apiClientId) {
-        logger.info("Attempting to getConsent - id: {}, for apiClientId: {}", consentId, apiClientId);
-        return ResponseEntity.ok(convertEntityToDto(consentService.getConsent(consentId, apiClientId)));
-    }
-
-    @Override
-    public ResponseEntity<DomesticPaymentConsent> authoriseConsent(String consentId, AuthorisePaymentConsentRequest request) {
-        logger.info("Attempting to authoriseConsent - id: {}, request: {}", consentId, request);
-        final PaymentAuthoriseConsentArgs paymentAuthoriseConsentArgs = new PaymentAuthoriseConsentArgs(consentId,
-                request.getApiClientId(), request.getResourceOwnerId(), request.getAuthorisedDebtorAccountId());
-
-        return ResponseEntity.ok(convertEntityToDto(consentService.authoriseConsent(paymentAuthoriseConsentArgs)));
-    }
-
-    @Override
-    public ResponseEntity<DomesticPaymentConsent> rejectConsent(String consentId, RejectConsentRequest request) {
-        logger.info("Attempting to rejectConsent - id: {}, request: {}", consentId, request);
-        return ResponseEntity.ok(convertEntityToDto(consentService.rejectConsent(consentId, request.getApiClientId(), request.getResourceOwnerId())));
-    }
-
-    @Override
-    public ResponseEntity<DomesticPaymentConsent> consumeConsent(String consentId, ConsumePaymentConsentRequest request) {
-        logger.info("Attempting to consumeConsent - id: {}, request: {}", consentId, request);
-        return ResponseEntity.ok(convertEntityToDto(consentService.consumeConsent(consentId, request.getApiClientId())));
-    }
-
-    private DomesticPaymentConsent convertEntityToDto(DomesticPaymentConsentEntity entity) {
-        final DomesticPaymentConsent dto = new DomesticPaymentConsent();
-        dto.setId(entity.getId());
-        dto.setStatus(entity.getStatus());
-        dto.setRequestObj(entity.getRequestObj());
-        dto.setRequestVersion(entity.getRequestVersion());
-        dto.setApiClientId(entity.getApiClientId());
-        dto.setResourceOwnerId(entity.getResourceOwnerId());
-        dto.setAuthorisedDebtorAccountId(entity.getAuthorisedDebtorAccountId());
-        dto.setIdempotencyKey(entity.getIdempotencyKey());
-        dto.setIdempotencyKeyExpiration(entity.getIdempotencyKeyExpiration());
-        dto.setCharges(entity.getCharges());
-        dto.setCreationDateTime(entity.getCreationDateTime());
-        dto.setStatusUpdateDateTime(entity.getStatusUpdatedDateTime());
-        return dto;
-    }
 }


### PR DESCRIPTION
Refactoring the DomesticPaymentConsentApi, removing the class level RequestMapping annotation from the interface and instead supplying it in the version specific controller impl.

Extracting BaseDomesticPaymentConsentApiController from DomesticPaymentConsentApiController, this class contains the common controller logic that is the same across versions. Version specific controllers extend the Base and supply the OBVersion parameter as well as the annotations to wire the controller in Spring and to specify the RequestMapping (as the URL pattern is version specific).

The same pattern will be followed for all Consent API controllers.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440