### PR TITLE
1493: Enforce OB Consent API version backwards compatibility rules

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/ConsentStoreApiConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/ConsentStoreApiConfiguration.java
@@ -15,16 +15,27 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.api;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreConfiguration;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 @Configuration
 @ComponentScan(basePackageClasses = ConsentStoreApiConfiguration.class)
+@Order(value = Ordered.HIGHEST_PRECEDENCE)
 public class ConsentStoreApiConfiguration {
 
     // Default to 24hours
@@ -34,5 +45,44 @@ public class ConsentStoreApiConfiguration {
     @Bean
     public Supplier<DateTime> getIdempotencyExpirationSupplier() {
         return () -> DateTime.now().plusSeconds(idempotencyExpirationDuration);
+    }
+
+    private List<OBVersion> supportedApiVersions() {
+        return List.of(OBVersion.v3_1_10, OBVersion.v4_0_0);
+    }
+
+    /**
+     * Dynamically creates and registers the versioned ConsentService objects, one service is created per supported
+     * OBVersion. These services are then wired into the ConsentApiControllers and will validate that consents are
+     * being accessed only by API versions that are supported, see {@link com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator}
+     * <p>
+     * The beans registered will be named as follows: $apiVersion$ConsentServiceInterfaceClassName e.g. v3.1.10AccountAccessConsentService
+     * <p>
+     * In order to autowire these services, components need to be annotated with @DependsOn({"versionedConsentServices"})
+     * to ensure that these services have been created prior to the component being constructed.
+     *
+     * @param consentServiceFactories the factories used to create the services
+     * @param beanFactory the bean factory to register the created services are beans
+     * @return List of created services
+     */
+    @Bean
+    public List<BaseConsentService> versionedConsentServices(List<ConsentServiceFactory> consentServiceFactories, ConfigurableListableBeanFactory beanFactory) {
+        final List<OBVersion> apiVersions = supportedApiVersions();
+        final List<BaseConsentService> consentServices = new ArrayList<>(consentServiceFactories.size() * apiVersions.size());
+
+        for (ConsentServiceFactory consentServiceFactory : consentServiceFactories) {
+            for (OBVersion apiVersion : apiVersions) {
+                BaseConsentService apiConsentService = consentServiceFactory.createApiConsentService(apiVersion);
+                final String beanName = apiVersion.getCanonicalName() + ConsentStoreConfiguration.getConsentServiceClassNameFromFactoryClass(consentServiceFactory.getClass());
+
+                // initializeBean is important as it ensures that the services are proxied by Spring, which enables it to add
+                // the runtime support for validation annotations i.e. @Validated and @Valid (and any other annotations supported by Spring).
+                apiConsentService = (BaseConsentService) beanFactory.initializeBean(apiConsentService, beanName);
+                beanFactory.registerSingleton(beanName, apiConsentService);
+                beanFactory.autowireBean(apiConsentService);
+                consentServices.add(apiConsentService);
+            }
+        }
+        return consentServices;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/BaseAccountAccessConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/BaseAccountAccessConsentApiController.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.api.account;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +40,11 @@ public class BaseAccountAccessConsentApiController implements AccountAccessConse
     private final AccountAccessConsentService consentService;
     private final OBVersion obVersion;
 
-    public BaseAccountAccessConsentApiController(AccountAccessConsentService consentService, OBVersion obVersion) {
-        this.consentService = Objects.requireNonNull(consentService, "consentService must be provided");
-        this.obVersion = Objects.requireNonNull(obVersion, "obVersion must be provided");
+    public BaseAccountAccessConsentApiController(AccountAccessConsentService accountAccessConsentService, OBVersion obVersion) {
+        requireNonNull(accountAccessConsentService, "accountAccessConsentService must be provided");
+        requireNonNull(obVersion, "obVersion must be provided");
+        this.consentService = accountAccessConsentService;
+        this.obVersion = obVersion;
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/account/v3_1_10/AccountAccessConsentApiController.java
@@ -16,6 +16,8 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.api.account.v3_1_10;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -28,11 +30,12 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class AccountAccessConsentApiController extends BaseAccountAccessConsentApiController {
 
     @Autowired
-    public AccountAccessConsentApiController(AccountAccessConsentService consentService) {
-        super(consentService, OBVersion.v3_1_10);
+    public AccountAccessConsentApiController(@Qualifier("v3.1.10AccountAccessConsentService") AccountAccessConsentService accountAccessConsentService) {
+        super(accountAccessConsentService, OBVersion.v3_1_10);
     }
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/customerinfo/v1_0/CustomerInfoConsentApiController.java
@@ -16,6 +16,8 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.api.customerinfo.v1_0;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -28,10 +30,11 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v1.0"})
 @RequestMapping(value = "/consent/store/v1.0")
+@DependsOn({"versionedConsentServices"})
 public class CustomerInfoConsentApiController extends BaseCustomerInfoConsentApiController {
 
     @Autowired
-    public CustomerInfoConsentApiController(CustomerInfoConsentService consentService) {
+    public CustomerInfoConsentApiController(@Qualifier("v3.1.10CustomerInfoConsentService") CustomerInfoConsentService consentService) {
         super(consentService, OBVersion.v1_0);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/funds/v3_1_10/FundsConfirmationConsentApiController.java
@@ -16,6 +16,8 @@
 package com.forgerock.sapi.gateway.rcs.consent.store.api.funds.v3_1_10;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -28,10 +30,11 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class FundsConfirmationConsentApiController extends BaseFundsConfirmationConsentApiController {
 
     @Autowired
-    public FundsConfirmationConsentApiController(FundsConfirmationConsentService consentService) {
+    public FundsConfirmationConsentApiController(@Qualifier("v3.1.10FundsConfirmationConsentService") FundsConfirmationConsentService consentService) {
         super(consentService, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,10 +36,11 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class DomesticPaymentConsentApiController extends BaseDomesticPaymentConsentApiController {
 
     @Autowired
-    public DomesticPaymentConsentApiController(DomesticPaymentConsentService consentService,
+    public DomesticPaymentConsentApiController(@Qualifier("v3.1.10DomesticPaymentConsentService") DomesticPaymentConsentService consentService,
                                                Supplier<DateTime> idempotencyKeyExpirationSupplier) {
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticscheduled/v3_1_10/DomesticScheduledPaymentConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,14 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class DomesticScheduledPaymentConsentApiController extends BaseDomesticScheduledPaymentConsentApiController {
 
     @Autowired
-    public DomesticScheduledPaymentConsentApiController(DomesticScheduledPaymentConsentService consentService,
-                                                        Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public DomesticScheduledPaymentConsentApiController(
+            @Qualifier("v3.1.10DomesticScheduledPaymentConsentService") DomesticScheduledPaymentConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domesticstandingorder/v3_1_10/DomesticStandingOrderConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,14 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class DomesticStandingOrderConsentApiController extends BaseDomesticStandingOrderConsentApiController {
 
     @Autowired
-    public DomesticStandingOrderConsentApiController(DomesticStandingOrderConsentService consentService,
-                                                     Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public DomesticStandingOrderConsentApiController(
+            @Qualifier("v3.1.10DomesticStandingOrderConsentService") DomesticStandingOrderConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/file/v3_1_10/FilePaymentConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,14 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class FilePaymentConsentApiController extends BaseFilePaymentConsentApiController {
 
     @Autowired
-    public FilePaymentConsentApiController(FilePaymentConsentService consentService,
-                                           Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public FilePaymentConsentApiController(
+            @Qualifier("v3.1.10FilePaymentConsentService") FilePaymentConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/international/v3_1_10/InternationalPaymentConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,13 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class InternationalPaymentConsentApiController extends BaseInternationalPaymentConsentApiController {
 
     @Autowired
-    public InternationalPaymentConsentApiController(InternationalPaymentConsentService consentService,
-                                              Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public InternationalPaymentConsentApiController(
+            @Qualifier("v3.1.10InternationalPaymentConsentService") InternationalPaymentConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,13 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class InternationalScheduledPaymentConsentApiController extends BaseInternationalScheduledPaymentConsentApiController {
 
     @Autowired
-    public InternationalScheduledPaymentConsentApiController(InternationalScheduledPaymentConsentService consentService,
-                                                            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public InternationalScheduledPaymentConsentApiController(
+            @Qualifier("v3.1.10InternationalScheduledPaymentConsentService") InternationalScheduledPaymentConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,13 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class InternationalStandingOrderConsentApiController extends BaseInternationalStandingOrderConsentApiController {
 
     @Autowired
-    public InternationalStandingOrderConsentApiController(InternationalStandingOrderConsentService consentService,
-                                                          Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public InternationalStandingOrderConsentApiController(
+            @Qualifier("v3.1.10InternationalStandingOrderConsentService") InternationalStandingOrderConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiController.java
@@ -19,6 +19,8 @@ import java.util.function.Supplier;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,11 +36,13 @@ import io.swagger.annotations.Api;
 @Controller
 @Api(tags = {"v3.1.10"})
 @RequestMapping(value = "/consent/store/v3.1.10")
+@DependsOn({"versionedConsentServices"})
 public class DomesticVRPConsentApiController extends BaseDomesticVRPConsentApiController {
 
     @Autowired
-    public DomesticVRPConsentApiController(DomesticVRPConsentService consentService,
-                                           Supplier<DateTime> idempotencyKeyExpirationSupplier) {
+    public DomesticVRPConsentApiController(
+            @Qualifier("v3.1.10DomesticVRPConsentService")DomesticVRPConsentService consentService,
+            Supplier<DateTime> idempotencyKeyExpirationSupplier) {
         super(consentService, idempotencyKeyExpirationSupplier, OBVersion.v3_1_10);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/domestic/v3_1_10/DomesticPaymentConsentApiControllerTest.java
@@ -17,16 +17,29 @@ package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.domestic.v3_1_1
 
 import java.util.UUID;
 
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.CreateDomesticPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic.DomesticPaymentConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
 
 
 public class DomesticPaymentConsentApiControllerTest extends BasePaymentConsentApiControllerTest<DomesticPaymentConsent, CreateDomesticPaymentConsentRequest> {
+
+    @Autowired
+    @Qualifier("internalDomesticPaymentConsentService")
+    private DomesticPaymentConsentService consentService;
 
     public DomesticPaymentConsentApiControllerTest() {
         super(DomesticPaymentConsent.class);
@@ -38,17 +51,35 @@ public class DomesticPaymentConsentApiControllerTest extends BasePaymentConsentA
     }
 
     @Override
+    protected String createConsentEntityForVersionValidation(String apiClient, OBVersion version) {
+        final DomesticPaymentConsentEntity consent = new DomesticPaymentConsentEntity();
+        consent.setApiClientId(apiClient);
+        consent.setRequestVersion(version);
+        consent.setRequestObj(createFRConsent());
+        consent.setIdempotencyKey(UUID.randomUUID().toString());
+        consent.setIdempotencyKeyExpiration(DateTime.now().plusMinutes(5));
+        consent.setStatus(AccountAccessConsentStateModel.AWAITING_AUTHORISATION);
+        return consentService.createConsent(consent).getId();
+    }
+
+    @Override
     protected CreateDomesticPaymentConsentRequest buildCreateConsentRequest(String apiClientId) {
         return buildCreateDomesticPaymentConsentRequest(apiClientId, UUID.randomUUID().toString());
     }
 
     private static CreateDomesticPaymentConsentRequest buildCreateDomesticPaymentConsentRequest(String apiClientId, String idempotencyKey) {
         final CreateDomesticPaymentConsentRequest createDomesticPaymentConsentRequest = new CreateDomesticPaymentConsentRequest();
-        final OBWriteDomesticConsent4 paymentConsent = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
-        createDomesticPaymentConsentRequest.setConsentRequest(FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(paymentConsent));
+        final FRWriteDomesticConsent frWriteDomesticConsent = createFRConsent();
+        createDomesticPaymentConsentRequest.setConsentRequest(frWriteDomesticConsent);
         createDomesticPaymentConsentRequest.setApiClientId(apiClientId);
         createDomesticPaymentConsentRequest.setIdempotencyKey(idempotencyKey);
         return createDomesticPaymentConsentRequest;
+    }
+
+    private static FRWriteDomesticConsent createFRConsent() {
+        final OBWriteDomesticConsent4 paymentConsent = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
+        final FRWriteDomesticConsent frWriteDomesticConsent = FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(paymentConsent);
+        return frWriteDomesticConsent;
     }
 
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalscheduled/v3_1_10/InternationalScheduledPaymentConsentApiControllerTest.java
@@ -20,18 +20,30 @@ import static com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.
 import java.util.List;
 import java.util.UUID;
 
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRChargeBearerType;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentWithExchangeRateInformationApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalscheduled.v3_1_10.CreateInternationalScheduledPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentWithExchangeRateInformationApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalScheduledPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalScheduledPaymentConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory;
 
 public class InternationalScheduledPaymentConsentApiControllerTest extends BasePaymentConsentWithExchangeRateInformationApiControllerTest<InternationalScheduledPaymentConsent, CreateInternationalScheduledPaymentConsentRequest> {
+
+    @Autowired
+    @Qualifier("internalInternationalScheduledPaymentConsentService")
+    private InternationalScheduledPaymentConsentService consentService;
 
     public InternationalScheduledPaymentConsentApiControllerTest() {
         super(InternationalScheduledPaymentConsent.class);
@@ -40,6 +52,18 @@ public class InternationalScheduledPaymentConsentApiControllerTest extends BaseP
     @Override
     protected String getControllerEndpointName() {
         return "international-scheduled-payment-consents";
+    }
+
+    @Override
+    protected String createConsentEntityForVersionValidation(String apiClient, OBVersion version) {
+        final InternationalScheduledPaymentConsentEntity consent = new InternationalScheduledPaymentConsentEntity();
+        consent.setApiClientId(apiClient);
+        consent.setRequestVersion(version);
+        consent.setRequestObj(FRWriteInternationalScheduledConsentConverter.toFRWriteInternationalScheduledConsent(OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()));
+        consent.setIdempotencyKey(UUID.randomUUID().toString());
+        consent.setIdempotencyKeyExpiration(DateTime.now().plusMinutes(5));
+        consent.setStatus(AccountAccessConsentStateModel.AWAITING_AUTHORISATION);
+        return consentService.createConsent(consent).getId();
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/internationalstandingorder/v3_1_10/InternationalStandingOrderConsentApiControllerTest.java
@@ -17,15 +17,28 @@ package com.forgerock.sapi.gateway.rcs.consent.store.api.payment.internationalst
 
 import java.util.UUID;
 
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalStandingOrderConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalStandingOrderConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.BasePaymentConsentApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international.InternationalStandingOrderConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
 
 public class InternationalStandingOrderConsentApiControllerTest extends BasePaymentConsentApiControllerTest<InternationalStandingOrderConsent, CreateInternationalStandingOrderConsentRequest> {
+
+    @Autowired
+    @Qualifier("internalInternationalStandingOrderConsentService")
+    private InternationalStandingOrderConsentService consentService;
 
     public InternationalStandingOrderConsentApiControllerTest() {
         super(InternationalStandingOrderConsent.class);
@@ -41,12 +54,30 @@ public class InternationalStandingOrderConsentApiControllerTest extends BasePaym
         return buildCreateInternationalStandingOrderConsentRequest(apiClientId, UUID.randomUUID().toString());
     }
 
+    @Override
+    protected String createConsentEntityForVersionValidation(String apiClient, OBVersion version) {
+        final InternationalStandingOrderConsentEntity consent = new InternationalStandingOrderConsentEntity();
+        consent.setApiClientId(apiClient);
+        consent.setRequestVersion(version);
+        consent.setRequestObj(createFRConsent());
+        consent.setIdempotencyKey(UUID.randomUUID().toString());
+        consent.setIdempotencyKeyExpiration(DateTime.now().plusMinutes(5));
+        consent.setStatus(AccountAccessConsentStateModel.AWAITING_AUTHORISATION);
+        return consentService.createConsent(consent).getId();
+    }
+
     private static CreateInternationalStandingOrderConsentRequest buildCreateInternationalStandingOrderConsentRequest(String apiClientId, String idempotencyKey) {
         final CreateInternationalStandingOrderConsentRequest createInternationalStandingOrderConsentRequest = new CreateInternationalStandingOrderConsentRequest();
-        final OBWriteInternationalStandingOrderConsent6 paymentConsent = OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6();
-        createInternationalStandingOrderConsentRequest.setConsentRequest(FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent(paymentConsent));
+        final FRWriteInternationalStandingOrderConsent frWriteInternationalStandingOrderConsent = createFRConsent();
+        createInternationalStandingOrderConsentRequest.setConsentRequest(frWriteInternationalStandingOrderConsent);
         createInternationalStandingOrderConsentRequest.setApiClientId(apiClientId);
         createInternationalStandingOrderConsentRequest.setIdempotencyKey(idempotencyKey);
         return createInternationalStandingOrderConsentRequest;
+    }
+
+    private static FRWriteInternationalStandingOrderConsent createFRConsent() {
+        final OBWriteInternationalStandingOrderConsent6 paymentConsent = OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent6();
+        final FRWriteInternationalStandingOrderConsent frWriteInternationalStandingOrderConsent = FRWriteInternationalStandingOrderConsentConverter.toFRWriteInternationalStandingOrderConsent(paymentConsent);
+        return frWriteInternationalStandingOrderConsent;
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-api/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/api/payment/vrp/v3_1_10/DomesticVRPConsentApiControllerTest.java
@@ -19,17 +19,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVRPConsentConverters;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.BaseControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.RejectConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.AuthorisePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.vrp.v3_1_10.CreateDomesticVRPConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.BaseControllerTest;
-import com.forgerock.sapi.gateway.rcs.consent.store.api.payment.PaymentConsentValidationHelpers;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.AccountAccessConsentStateModel;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.DomesticVRPConsentService;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
@@ -40,6 +48,10 @@ public class DomesticVRPConsentApiControllerTest extends BaseControllerTest<Dome
 
     private static final String TEST_DEBTOR_ACC_ID = "acc-435345";
 
+    @Autowired
+    @Qualifier("internalDomesticVRPConsentService")
+    private DomesticVRPConsentService consentService;
+
     public DomesticVRPConsentApiControllerTest() {
         super(DomesticVRPConsent.class);
     }
@@ -47,6 +59,18 @@ public class DomesticVRPConsentApiControllerTest extends BaseControllerTest<Dome
     @Override
     protected String getControllerEndpointName() {
         return "domestic-vrp-consents";
+    }
+
+    @Override
+    protected String createConsentEntityForVersionValidation(String apiClient, OBVersion version) {
+        final DomesticVRPConsentEntity consent = new DomesticVRPConsentEntity();
+        consent.setApiClientId(apiClient);
+        consent.setRequestVersion(version);
+        consent.setRequestObj(createFRConsent());
+        consent.setIdempotencyKey(UUID.randomUUID().toString());
+        consent.setIdempotencyKeyExpiration(DateTime.now().plusMinutes(5));
+        consent.setStatus(AccountAccessConsentStateModel.AWAITING_AUTHORISATION);
+        return consentService.createConsent(consent).getId();
     }
 
     @Override
@@ -81,11 +105,17 @@ public class DomesticVRPConsentApiControllerTest extends BaseControllerTest<Dome
 
     private static CreateDomesticVRPConsentRequest buildCreateDomesticVRPConsentRequest(String apiClientId, String idempotencyKey) {
         final CreateDomesticVRPConsentRequest createDomesticVRPConsentRequest = new CreateDomesticVRPConsentRequest();
-        final OBDomesticVRPConsentRequest paymentConsent = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest();
-        createDomesticVRPConsentRequest.setConsentRequest(FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(paymentConsent));
+        final FRDomesticVRPConsent frDomesticVRPConsent = createFRConsent();
+        createDomesticVRPConsentRequest.setConsentRequest(frDomesticVRPConsent);
         createDomesticVRPConsentRequest.setApiClientId(apiClientId);
         createDomesticVRPConsentRequest.setIdempotencyKey(idempotencyKey);
         return createDomesticVRPConsentRequest;
+    }
+
+    private static FRDomesticVRPConsent createFRConsent() {
+        final OBDomesticVRPConsentRequest paymentConsent = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest();
+        final FRDomesticVRPConsent frDomesticVRPConsent = FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(paymentConsent);
+        return frDomesticVRPConsent;
     }
 
     @Test

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreConfiguration.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/ConsentStoreConfiguration.java
@@ -17,18 +17,26 @@ package com.forgerock.sapi.gateway.rcs.consent.store.repo;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.MongoRepoPackageMarker;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.BackwardsCompatibilityApiVersionValidator;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 import com.forgerock.sapi.gateway.uk.common.shared.spring.converter.JodaTimeConverters;
 
@@ -38,6 +46,7 @@ import jakarta.annotation.PostConstruct;
 @ComponentScan(basePackageClasses = ConsentStoreConfiguration.class)
 @EnableMongoRepositories(basePackageClasses = MongoRepoPackageMarker.class)
 @EnableMongoAuditing
+@Order(value = Ordered.HIGHEST_PRECEDENCE)
 public class ConsentStoreConfiguration {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -65,5 +74,45 @@ public class ConsentStoreConfiguration {
     public MongoCustomConversions mongoCustomConversions() {
         logger.info("Installing joda time converters for Mongo");
         return new MongoCustomConversions(new ArrayList<>(JodaTimeConverters.getConvertersToRegister()));
+    }
+
+    @Bean
+    public ApiVersionValidator apiVersionValidator() {
+        return new BackwardsCompatibilityApiVersionValidator();
+    }
+
+    /**
+     * Dynamically creates and registers the internal ConsentService objects. The internal services are used by
+     * RCS code which is not being invoked by the Consent Store REST API i.e. for internal use cases where there is
+     * no requirement to check an API version.
+     * <p>
+     * Currently, the internal services are used for the Consent Details and Decision UI functionality.
+     * <p>
+     * The beans registered will be named as follows: internal$ConsentServiceInterfaceClassName e.g. internalAccountAccessConsentService
+     * <p>
+     * In order to autowire these services, components need to be annotated with @DependsOn({"internalConsentServices"})
+     * to ensure that these services have been created prior to the component being constructed.
+     *
+     * @param consentServiceFactories the factories used to create the services
+     * @param beanFactory the bean factory to register the created services are beans
+     * @return List of created services
+     */
+    @Bean
+    public List<BaseConsentService> internalConsentServices(List<ConsentServiceFactory> consentServiceFactories, ConfigurableListableBeanFactory beanFactory) {
+        return consentServiceFactories.stream().map(consentServiceFactory -> {
+            BaseConsentService internalConsentService = consentServiceFactory.createInternalConsentService();
+            final String beanName = "internal" + getConsentServiceClassNameFromFactoryClass(consentServiceFactory.getClass());
+
+            // initializeBean is important as it ensures that the services are proxied by Spring, which enables it to add
+            // the runtime support for validation annotations i.e. @Validated and @Valid (and any other annotations supported by Spring).
+            internalConsentService = (BaseConsentService) beanFactory.initializeBean(internalConsentService, beanName);
+            beanFactory.registerSingleton(beanName, internalConsentService);
+            beanFactory.autowireBean(internalConsentService);
+            return internalConsentService;
+        }).toList();
+    }
+
+    public static String getConsentServiceClassNameFromFactoryClass(Class<? extends ConsentServiceFactory> clazz) {
+        return clazz.getSimpleName().replace("Factory", "");
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/exception/ConsentStoreException.java
@@ -24,6 +24,7 @@ public class ConsentStoreException extends RuntimeException {
         INVALID_STATE_TRANSITION,
         INVALID_CONSENT_DECISION,
         INVALID_DEBTOR_ACCOUNT,
+        INVALID_API_VERSION,
         CONSENT_REAUTHENTICATION_NOT_SUPPORTED,
         IDEMPOTENCY_ERROR
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/ConsentServiceFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Consumer;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.BaseConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+public abstract class ConsentServiceFactory<T extends BaseConsentEntity<?>, A extends AuthoriseConsentArgs, S extends BaseConsentService<T, A>> {
+
+    protected final MongoRepository<T, String> repo;
+    protected final ApiVersionValidator apiVersionValidator;
+
+    protected ConsentServiceFactory(MongoRepository<T, String> repo, ApiVersionValidator apiVersionValidator) {
+        this.repo = requireNonNull(repo, "repo cannot be null");
+        this.apiVersionValidator = requireNonNull(apiVersionValidator, "apiVersionValidator cannot be null");
+    }
+
+    protected abstract S createBaseConsentService();
+
+    /**
+     * Creates a ConsentService to be used by the RCS internally, this service applies no API version validation
+     * @return the ConsentService
+     */
+    public S createInternalConsentService() {
+        return createBaseConsentService();
+    }
+
+    /**
+     * Creates an API Consent Service, this service is tied to a particular API version and will validate consents
+     * retrieved from the repository can be accessed by that version.
+     *
+     * @param apiVersion OBVersion being used to access the consent
+     * @return the ConsentService
+     */
+    public S createApiConsentService(OBVersion apiVersion) {
+        requireNonNull(apiVersion, "apiVersion cannot be null");
+        final S baseConsentService = createBaseConsentService();
+        baseConsentService.setApiVersionValidationStrategy(applyApiVersionValidator(apiVersion));
+        return baseConsentService;
+    }
+
+    private Consumer<T> applyApiVersionValidator(OBVersion apiVersion) {
+        return consent -> {
+            if (!apiVersionValidator.canAccessResourceUsingApiVersion(consent.getRequestVersion(), apiVersion)) {
+                throw new ConsentStoreException(ErrorType.INVALID_API_VERSION, consent.getId(),
+                        "Consent created using API version: " + consent.getRequestVersion().getCanonicalVersion()
+                                + " cannot be accessed using version: " + apiVersion.getCanonicalVersion());
+            }
+        };
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/AccountAccessConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/AccountAccessConsentServiceFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.account.AccountAccessConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.account.AccountAccessConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class AccountAccessConsentServiceFactory extends ConsentServiceFactory<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs, DefaultAccountAccessConsentService> {
+
+    @Autowired
+    public AccountAccessConsentServiceFactory(AccountAccessConsentRepository repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultAccountAccessConsentService createBaseConsentService() {
+        return new DefaultAccountAccessConsentService(repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentService.java
@@ -15,19 +15,17 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account;
 
-import org.springframework.stereotype.Service;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.account.AccountAccessConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.account.AccountAccessConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultAccountAccessConsentService extends BaseConsentService<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs> implements AccountAccessConsentService {
 
     private final String revokedStatus;
 
-    public DefaultAccountAccessConsentService(AccountAccessConsentRepository repo) {
+    public DefaultAccountAccessConsentService(MongoRepository<AccountAccessConsentEntity, String> repo) {
         super(repo, IntentType.ACCOUNT_ACCESS_CONSENT::generateIntentId, AccountAccessConsentStateModel.getInstance());
         revokedStatus = AccountAccessConsentStateModel.getInstance().getRevokedConsentStatus();
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/CustomerInfoConsentServiceFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class CustomerInfoConsentServiceFactory extends ConsentServiceFactory<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs, DefaultCustomerInfoAccessConsentService> {
+
+    @Autowired
+    public CustomerInfoConsentServiceFactory(MongoRepository<CustomerInfoConsentEntity, String> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultCustomerInfoAccessConsentService createBaseConsentService() {
+        return new DefaultCustomerInfoAccessConsentService(repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/customerinfo/DefaultCustomerInfoAccessConsentService.java
@@ -15,18 +15,17 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo;
 
+import org.springframework.data.mongodb.repository.MongoRepository;
+
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.CustomerInfoConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.customerinfo.CustomerInfoConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DefaultCustomerInfoAccessConsentService extends BaseConsentService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> implements CustomerInfoConsentService {
 
     private final String revokedStatus;
 
-    public DefaultCustomerInfoAccessConsentService(CustomerInfoConsentRepository repo) {
+    public DefaultCustomerInfoAccessConsentService(MongoRepository<CustomerInfoConsentEntity, String> repo) {
         super(repo, IntentType.CUSTOMER_INFO_CONSENT::generateIntentId, CustomerInfoConsentStateModel.getInstance());
         revokedStatus = CustomerInfoConsentStateModel.getInstance().getRevokedConsentStatus();
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/DefaultFundsConfirmationAccessConsentService.java
@@ -15,19 +15,17 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
 
-import org.springframework.stereotype.Service;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.funds.FundsConfirmationConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultFundsConfirmationAccessConsentService extends BaseConsentService<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> implements FundsConfirmationConsentService {
 
     private final String revokedStatus;
 
-    public DefaultFundsConfirmationAccessConsentService(FundsConfirmationConsentRepository repo) {
+    public DefaultFundsConfirmationAccessConsentService(MongoRepository<FundsConfirmationConsentEntity, String> repo) {
         super(repo, IntentType.FUNDS_CONFIRMATION_CONSENT::generateIntentId, FundsConfirmationConsentStateModel.getInstance());
         revokedStatus = FundsConfirmationConsentStateModel.getInstance().getRevokedConsentStatus();
     }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/funds/FundsConfirmationConsentServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.funds.FundsConfirmationConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class FundsConfirmationConsentServiceFactory extends ConsentServiceFactory<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs, DefaultFundsConfirmationAccessConsentService> {
+
+    @Autowired
+    public FundsConfirmationConsentServiceFactory(MongoRepository<FundsConfirmationConsentEntity, String> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+    @Override
+    protected DefaultFundsConfirmationAccessConsentService createBaseConsentService() {
+        return new DefaultFundsConfirmationAccessConsentService(repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticPaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticPaymentConsentService.java
@@ -15,18 +15,15 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticPaymentConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.domestic.DomesticPaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultDomesticPaymentConsentService extends BasePaymentConsentService<DomesticPaymentConsentEntity, PaymentAuthoriseConsentArgs> implements DomesticPaymentConsentService {
 
-    public DefaultDomesticPaymentConsentService(DomesticPaymentConsentRepository repo) {
+    public DefaultDomesticPaymentConsentService(PaymentConsentRepository<DomesticPaymentConsentEntity> repo) {
         super(repo, IntentType.PAYMENT_DOMESTIC_CONSENT::generateIntentId);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticScheduledPaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticScheduledPaymentConsentService.java
@@ -15,18 +15,15 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticScheduledPaymentConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.domestic.DomesticScheduledPaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultDomesticScheduledPaymentConsentService extends BasePaymentConsentService<DomesticScheduledPaymentConsentEntity, PaymentAuthoriseConsentArgs> implements DomesticScheduledPaymentConsentService {
 
-    public DefaultDomesticScheduledPaymentConsentService(DomesticScheduledPaymentConsentRepository repo) {
+    public DefaultDomesticScheduledPaymentConsentService(PaymentConsentRepository<DomesticScheduledPaymentConsentEntity> repo) {
         super(repo, IntentType.PAYMENT_DOMESTIC_SCHEDULED_CONSENT::generateIntentId);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticStandingOrderConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DefaultDomesticStandingOrderConsentService.java
@@ -15,18 +15,15 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticStandingOrderConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.domestic.DomesticStandingOrderConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultDomesticStandingOrderConsentService extends BasePaymentConsentService<DomesticStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> implements DomesticStandingOrderConsentService {
 
-    public DefaultDomesticStandingOrderConsentService(DomesticStandingOrderConsentRepository repo) {
+    public DefaultDomesticStandingOrderConsentService(PaymentConsentRepository<DomesticStandingOrderConsentEntity> repo) {
         super(repo, IntentType.PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT::generateIntentId);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticPaymentConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticPaymentConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class DomesticPaymentConsentServiceFactory extends ConsentServiceFactory<DomesticPaymentConsentEntity, PaymentAuthoriseConsentArgs, DefaultDomesticPaymentConsentService> {
+
+    @Autowired
+    public DomesticPaymentConsentServiceFactory(PaymentConsentRepository<DomesticPaymentConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultDomesticPaymentConsentService createBaseConsentService() {
+        return new DefaultDomesticPaymentConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticScheduledPaymentConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticScheduledPaymentConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticScheduledPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class DomesticScheduledPaymentConsentServiceFactory extends ConsentServiceFactory<DomesticScheduledPaymentConsentEntity, PaymentAuthoriseConsentArgs, DefaultDomesticScheduledPaymentConsentService> {
+
+    @Autowired
+    public DomesticScheduledPaymentConsentServiceFactory(PaymentConsentRepository<DomesticScheduledPaymentConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultDomesticScheduledPaymentConsentService createBaseConsentService() {
+        return new DefaultDomesticScheduledPaymentConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticStandingOrderConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/domestic/DomesticStandingOrderConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domestic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class DomesticStandingOrderConsentServiceFactory extends ConsentServiceFactory<DomesticStandingOrderConsentEntity, PaymentAuthoriseConsentArgs, DefaultDomesticStandingOrderConsentService> {
+
+    @Autowired
+    public DomesticStandingOrderConsentServiceFactory(PaymentConsentRepository<DomesticStandingOrderConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultDomesticStandingOrderConsentService createBaseConsentService() {
+        return new DefaultDomesticStandingOrderConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/file/DefaultFilePaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/file/DefaultFilePaymentConsentService.java
@@ -15,20 +15,17 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.file;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.file.FilePaymentConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException.ErrorType;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.file.FilePaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultFilePaymentConsentService extends BasePaymentConsentService<FilePaymentConsentEntity, PaymentAuthoriseConsentArgs> implements FilePaymentConsentService {
 
-    public DefaultFilePaymentConsentService(FilePaymentConsentRepository repo) {
+    public DefaultFilePaymentConsentService(PaymentConsentRepository<FilePaymentConsentEntity> repo) {
         super(repo, IntentType.PAYMENT_FILE_CONSENT::generateIntentId, FilePaymentConsentStateModel.getInstance());
     }
 

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/file/FilePaymentConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/file/FilePaymentConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.file;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.file.FilePaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class FilePaymentConsentServiceFactory extends ConsentServiceFactory<FilePaymentConsentEntity, PaymentAuthoriseConsentArgs, DefaultFilePaymentConsentService> {
+
+    @Autowired
+    public FilePaymentConsentServiceFactory(PaymentConsentRepository<FilePaymentConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultFilePaymentConsentService createBaseConsentService() {
+        return new DefaultFilePaymentConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalPaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalPaymentConsentService.java
@@ -15,18 +15,15 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalPaymentConsentEntity;
-import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.international.InternationalPaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultInternationalPaymentConsentService extends BasePaymentConsentService<InternationalPaymentConsentEntity, PaymentAuthoriseConsentArgs> implements InternationalPaymentConsentService {
 
-    public DefaultInternationalPaymentConsentService(InternationalPaymentConsentRepository repo) {
+    public DefaultInternationalPaymentConsentService(PaymentConsentRepository<InternationalPaymentConsentEntity> repo) {
         super(repo, IntentType.PAYMENT_INTERNATIONAL_CONSENT::generateIntentId);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalScheduledPaymentConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalScheduledPaymentConsentService.java
@@ -15,15 +15,12 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalScheduledPaymentConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultInternationalScheduledPaymentConsentService extends BasePaymentConsentService<InternationalScheduledPaymentConsentEntity, PaymentAuthoriseConsentArgs> implements InternationalScheduledPaymentConsentService {
 
     public DefaultInternationalScheduledPaymentConsentService(PaymentConsentRepository<InternationalScheduledPaymentConsentEntity> repo) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/DefaultInternationalStandingOrderConsentService.java
@@ -15,15 +15,12 @@
  */
 package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
 
-import org.springframework.stereotype.Service;
-
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.BasePaymentConsentService;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultInternationalStandingOrderConsentService extends BasePaymentConsentService<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs> implements InternationalStandingOrderConsentService {
 
     public DefaultInternationalStandingOrderConsentService(PaymentConsentRepository<InternationalStandingOrderConsentEntity> repo) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalPaymentConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalPaymentConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class InternationalPaymentConsentServiceFactory extends ConsentServiceFactory<InternationalPaymentConsentEntity, PaymentAuthoriseConsentArgs, DefaultInternationalPaymentConsentService> {
+
+    @Autowired
+    public InternationalPaymentConsentServiceFactory(PaymentConsentRepository<InternationalPaymentConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultInternationalPaymentConsentService createBaseConsentService() {
+        return new DefaultInternationalPaymentConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalScheduledPaymentConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalScheduledPaymentConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalScheduledPaymentConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class InternationalScheduledPaymentConsentServiceFactory extends ConsentServiceFactory<InternationalScheduledPaymentConsentEntity, PaymentAuthoriseConsentArgs, DefaultInternationalScheduledPaymentConsentService> {
+
+    @Autowired
+    public InternationalScheduledPaymentConsentServiceFactory(PaymentConsentRepository<InternationalScheduledPaymentConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultInternationalScheduledPaymentConsentService createBaseConsentService() {
+        return new DefaultInternationalScheduledPaymentConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalStandingOrderConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/international/InternationalStandingOrderConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.international;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.international.InternationalStandingOrderConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class InternationalStandingOrderConsentServiceFactory extends ConsentServiceFactory<InternationalStandingOrderConsentEntity, PaymentAuthoriseConsentArgs, DefaultInternationalStandingOrderConsentService> {
+
+    @Autowired
+    public InternationalStandingOrderConsentServiceFactory(PaymentConsentRepository<InternationalStandingOrderConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultInternationalStandingOrderConsentService createBaseConsentService() {
+        return new DefaultInternationalStandingOrderConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentService.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DefaultDomesticVRPConsentService.java
@@ -18,7 +18,6 @@ package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
 import java.util.Optional;
 
 import org.joda.time.DateTime;
-import org.springframework.stereotype.Service;
 
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.exception.ConsentStoreException;
@@ -28,7 +27,6 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentServ
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-@Service
 public class DefaultDomesticVRPConsentService extends BaseConsentService<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs> implements DomesticVRPConsentService {
 
     public DefaultDomesticVRPConsentService(PaymentConsentRepository<DomesticVRPConsentEntity> repo) {

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentServiceFactory.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/payment/vrp/DomesticVRPConsentServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.vrp.DomesticVRPConsentEntity;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.mongo.payment.PaymentConsentRepository;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentServiceFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.PaymentAuthoriseConsentArgs;
+import com.forgerock.sapi.gateway.rcs.consent.store.repo.version.ApiVersionValidator;
+
+@Service
+public class DomesticVRPConsentServiceFactory extends ConsentServiceFactory<DomesticVRPConsentEntity, PaymentAuthoriseConsentArgs, DefaultDomesticVRPConsentService> {
+
+    @Autowired
+    public DomesticVRPConsentServiceFactory(PaymentConsentRepository<DomesticVRPConsentEntity> repo, ApiVersionValidator apiVersionValidator) {
+        super(repo, apiVersionValidator);
+    }
+
+    @Override
+    protected DefaultDomesticVRPConsentService createBaseConsentService() {
+        return new DefaultDomesticVRPConsentService((PaymentConsentRepository)repo);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/ApiVersionValidator.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/ApiVersionValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.version;
+
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+/**
+ * Validator which checks if a resource (typically a Consent) can be accessed using a particular API version.
+ */
+public interface ApiVersionValidator {
+
+    /**
+     * Tests if a resource can be accessed using a particular API version.
+     *
+     * @param creationVersion the version of the API used to create the resource
+     * @param accessVersion   the version of the API used to access the resource
+     * @return true if the resource can be accessed with the given version.
+     */
+    boolean canAccessResourceUsingApiVersion(OBVersion creationVersion, OBVersion accessVersion);
+
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/BackwardsCompatibilityApiVersionValidator.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/main/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/BackwardsCompatibilityApiVersionValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.version;
+
+import static java.util.Objects.requireNonNull;
+
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+/**
+ * Implementation of {@link ApiVersionValidator} which enforces that only backwards compatibility is supported
+ * i.e. a resource can be accessed by the current API version or a future API version only.
+ */
+public class BackwardsCompatibilityApiVersionValidator implements ApiVersionValidator {
+
+    @Override
+    public boolean canAccessResourceUsingApiVersion(OBVersion creationVersion, OBVersion accessVersion) {
+        requireNonNull(creationVersion, "creationVersion must be provided");
+        requireNonNull(accessVersion, "accessVersion must be provided");
+        return creationVersion == accessVersion || creationVersion.isBeforeVersion(accessVersion);
+    }
+}

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentServiceTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/service/account/DefaultAccountAccessConsentServiceTest.java
@@ -21,16 +21,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Path;
-
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRReadConsentConverter;
@@ -42,6 +39,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.BaseConsentServ
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentStateModel;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
 import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
 import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
 import uk.org.openbanking.datamodel.v3.account.OBRisk2;
@@ -50,10 +50,11 @@ import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
+@DependsOn({"internalConsentServices"})
 public class DefaultAccountAccessConsentServiceTest extends BaseConsentServiceTest<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs> {
 
     @Autowired
-    private DefaultAccountAccessConsentService accountAccessConsentService;
+    private AccountAccessConsentService accountAccessConsentService;
 
     @Override
     protected ConsentStateModel getConsentStateModel() {
@@ -62,7 +63,7 @@ public class DefaultAccountAccessConsentServiceTest extends BaseConsentServiceTe
 
     @Override
     protected BaseConsentService<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs> getConsentServiceToTest() {
-        return accountAccessConsentService;
+        return (BaseConsentService<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs>) accountAccessConsentService;
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/BackwardsCompatibilityApiVersionValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rcs-consent-store/secure-api-gateway-ob-uk-rcs-consent-store-repo/src/test/java/com/forgerock/sapi/gateway/rcs/consent/store/repo/version/BackwardsCompatibilityApiVersionValidatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rcs.consent.store.repo.version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+class BackwardsCompatibilityApiVersionValidatorTest {
+
+    private final BackwardsCompatibilityApiVersionValidator apiVersionValidator = new BackwardsCompatibilityApiVersionValidator();
+
+    @Test
+    void shouldAllowConsentToBeAccessedUsingSameApiVersion() {
+        assertTrue(apiVersionValidator.canAccessResourceUsingApiVersion(OBVersion.v3_1_10, OBVersion.v3_1_10));
+    }
+
+    @Test
+    void shouldAllowConsentToBeAccessedFromFutureApiVersion() {
+        assertTrue(apiVersionValidator.canAccessResourceUsingApiVersion(OBVersion.v3_1_10, OBVersion.v4_0_0));
+    }
+
+    @Test
+    void shouldFailToAccessConsentFromOlderApiVersion() {
+        assertFalse(apiVersionValidator.canAccessResourceUsingApiVersion(OBVersion.v4_0_0, OBVersion.v3_1_10));
+    }
+
+    @Test
+    void shouldFailIfParamsAreNull() {
+        NullPointerException npe = assertThrows(NullPointerException.class,
+                () -> apiVersionValidator.canAccessResourceUsingApiVersion(null, null));
+        assertThat(npe).hasMessage("creationVersion must be provided");
+
+        npe = assertThrows(NullPointerException.class,
+                () -> apiVersionValidator.canAccessResourceUsingApiVersion(OBVersion.v4_0_0, null));
+        assertThat(npe).hasMessage("accessVersion must be provided");
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/account/AccountAccessConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/account/AccountAccessConsentDecisionService.java
@@ -17,6 +17,8 @@ package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.account;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.decision.ConsentDecisionDeserialized;
@@ -29,9 +31,10 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.account.Account
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class AccountAccessConsentDecisionService extends BaseConsentDecisionService<AccountAccessConsentEntity, AccountAccessAuthoriseConsentArgs> {
 
-    public AccountAccessConsentDecisionService(AccountAccessConsentService accountAccessConsentService) {
+    public AccountAccessConsentDecisionService(@Qualifier("internalAccountAccessConsentService") AccountAccessConsentService accountAccessConsentService) {
         super(IntentType.ACCOUNT_ACCESS_CONSENT, accountAccessConsentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/customerinfo/CustomerInfoConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.customerinfo;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.api.dto.consent.decision.ConsentDecisionDeserialized;
@@ -25,9 +27,10 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.customerinfo.Cu
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class CustomerInfoConsentDecisionService extends BaseConsentDecisionService<CustomerInfoConsentEntity, CustomerInfoAuthoriseConsentArgs> {
 
-    public CustomerInfoConsentDecisionService(CustomerInfoConsentService customerInfoConsentService) {
+    public CustomerInfoConsentDecisionService(@Qualifier("internalCustomerInfoConsentService")CustomerInfoConsentService customerInfoConsentService) {
         super(IntentType.CUSTOMER_INFO_CONSENT, customerInfoConsentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/funds/FundsConfirmationConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/funds/FundsConfirmationConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.funds;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRFinancialAccount;
@@ -27,8 +29,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.funds.FundsConf
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class FundsConfirmationConsentDecisionService extends BaseConsentDecisionService<FundsConfirmationConsentEntity, FundsConfirmationAuthoriseConsentArgs> {
-    public FundsConfirmationConsentDecisionService(FundsConfirmationConsentService consentService) {
+    public FundsConfirmationConsentDecisionService(@Qualifier("internalFundsConfirmationConsentService") FundsConfirmationConsentService consentService) {
         super(IntentType.FUNDS_CONFIRMATION_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticPaymentConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticPaymentConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,10 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domesti
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticPaymentConsentDecisionService extends BasePaymentConsentDecisionService<DomesticPaymentConsentEntity> {
 
-    public DomesticPaymentConsentDecisionService(DomesticPaymentConsentService consentService) {
+    public DomesticPaymentConsentDecisionService(@Qualifier("internalDomesticPaymentConsentService") DomesticPaymentConsentService consentService) {
         super(IntentType.PAYMENT_DOMESTIC_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticScheduledPaymentConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticScheduledPaymentConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domesti
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticScheduledPaymentConsentDecisionService extends BasePaymentConsentDecisionService<DomesticScheduledPaymentConsentEntity> {
 
-    public DomesticScheduledPaymentConsentDecisionService(DomesticScheduledPaymentConsentService consentService) {
+    public DomesticScheduledPaymentConsentDecisionService(
+            @Qualifier("internalDomesticScheduledPaymentConsentService") DomesticScheduledPaymentConsentService consentService) {
+
         super(IntentType.PAYMENT_DOMESTIC_SCHEDULED_CONSENT, consentService);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticStandingOrderConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/domestic/DomesticStandingOrderConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.domesti
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Service
+@DependsOn({"internalConsentServices"})
 public class DomesticStandingOrderConsentDecisionService extends BasePaymentConsentDecisionService<DomesticStandingOrderConsentEntity> {
 
-    public DomesticStandingOrderConsentDecisionService(DomesticStandingOrderConsentService consentService) {
+    public DomesticStandingOrderConsentDecisionService(
+            @Qualifier("internalDomesticStandingOrderConsentService") DomesticStandingOrderConsentService consentService) {
+
         super(IntentType.PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, consentService);
     }
 }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/file/FilePaymentConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/file/FilePaymentConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.file;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.file.Fi
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class FilePaymentConsentDecisionService extends BasePaymentConsentDecisionService<FilePaymentConsentEntity> {
 
-    public FilePaymentConsentDecisionService(FilePaymentConsentService consentService) {
+    public FilePaymentConsentDecisionService(
+            @Qualifier("internalFilePaymentConsentService") FilePaymentConsentService consentService) {
+
         super(IntentType.PAYMENT_FILE_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalPaymentConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalPaymentConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.interna
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalPaymentConsentDecisionService extends BasePaymentConsentDecisionService<InternationalPaymentConsentEntity> {
 
-    public InternationalPaymentConsentDecisionService(InternationalPaymentConsentService consentService) {
+    public InternationalPaymentConsentDecisionService(
+            @Qualifier("internalInternationalPaymentConsentService") InternationalPaymentConsentService consentService) {
+
         super(IntentType.PAYMENT_INTERNATIONAL_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalScheduledPaymentConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalScheduledPaymentConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,11 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.interna
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalScheduledPaymentConsentDecisionService extends BasePaymentConsentDecisionService<InternationalScheduledPaymentConsentEntity> {
 
-    public InternationalScheduledPaymentConsentDecisionService(InternationalScheduledPaymentConsentService consentService) {
+    public InternationalScheduledPaymentConsentDecisionService(
+            @Qualifier("internalInternationalScheduledPaymentConsentService") InternationalScheduledPaymentConsentService consentService) {
         super(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/international/InternationalStandingOrderConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.interna
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalStandingOrderConsentDecisionService extends BasePaymentConsentDecisionService<InternationalStandingOrderConsentEntity> {
 
-    public InternationalStandingOrderConsentDecisionService(InternationalStandingOrderConsentService consentService) {
+    public InternationalStandingOrderConsentDecisionService(
+            @Qualifier("internalInternationalStandingOrderConsentService") InternationalStandingOrderConsentService consentService) {
+
         super(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/payment/vrp/DomesticVRPConsentDecisionService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.vrp;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.rcs.server.api.decision.payment.BasePaymentConsentDecisionService;
@@ -23,9 +25,11 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.payment.vrp.Dom
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticVRPConsentDecisionService extends BasePaymentConsentDecisionService<DomesticVRPConsentEntity> {
 
-    public DomesticVRPConsentDecisionService(DomesticVRPConsentService consentService) {
+    public DomesticVRPConsentDecisionService(
+            @Qualifier("internalDomesticVRPConsentService") DomesticVRPConsentService consentService) {
         super(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, consentService);
     }
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/account/AccountAccessConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/account/AccountAccessConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.account;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRReadConsentData;
@@ -29,11 +31,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class AccountAccessConsentDetailsService extends BaseConsentDetailsService<AccountAccessConsentEntity, AccountsConsentDetails> {
 
     private final AccountService accountService;
 
-    public AccountAccessConsentDetailsService(ConsentService<AccountAccessConsentEntity, ?> consentService,
+    public AccountAccessConsentDetailsService(@Qualifier("internalAccountAccessConsentService") ConsentService<AccountAccessConsentEntity, ?> consentService,
             ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService, AccountService accountService) {
 
         super(IntentType.ACCOUNT_ACCESS_CONSENT, AccountsConsentDetails::new, consentService,

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/customerinfo/CustomerInfoConsentDetailsService.java
@@ -26,17 +26,20 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.customerinfo.Cus
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 import org.joda.time.LocalDate;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class CustomerInfoConsentDetailsService extends BaseConsentDetailsService<CustomerInfoConsentEntity, CustomerInfoConsentDetails> {
 
     private final CustomerInfoService customerInfoService;
 
     public CustomerInfoConsentDetailsService(
-            ConsentService<CustomerInfoConsentEntity, ?> consentService,
+            @Qualifier("internalCustomerInfoConsentService") ConsentService<CustomerInfoConsentEntity, ?> consentService,
             ApiProviderConfiguration apiProviderConfiguration,
             ApiClientServiceClient apiClientService,
             CustomerInfoService customerInfoService

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/funds/FundsConfirmationConsentDetailsService.java
@@ -18,6 +18,8 @@ package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.funds;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRAccountWithBalance;
@@ -38,12 +40,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
+@DependsOn({"internalConsentServices"})
 public class FundsConfirmationConsentDetailsService extends BaseConsentDetailsService<FundsConfirmationConsentEntity, FundsConfirmationConsentDetails> {
 
     private final AccountService accountService;
 
     public FundsConfirmationConsentDetailsService(
-            ConsentService<FundsConfirmationConsentEntity, ?> consentService,
+            @Qualifier("internalFundsConfirmationConsentService")ConsentService<FundsConfirmationConsentEntity, ?> consentService,
             ApiProviderConfiguration apiProviderConfiguration,
             ApiClientServiceClient apiClientService,
             AccountService accountService) {

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticPaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticPaymentConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -31,10 +33,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticPaymentConsentDetailsService extends BasePaymentConsentDetailsService<DomesticPaymentConsentEntity, DomesticPaymentConsentDetails> {
 
-    public DomesticPaymentConsentDetailsService(ConsentService<DomesticPaymentConsentEntity, ?> consentService,
-            ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
+    public DomesticPaymentConsentDetailsService(
+            @Qualifier("internalDomesticPaymentConsentService") ConsentService<DomesticPaymentConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
             AccountService accountService) {
 
         super(IntentType.PAYMENT_DOMESTIC_CONSENT, DomesticPaymentConsentDetails::new, consentService,

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticScheduledPaymentConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -31,9 +33,15 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticScheduledPaymentConsentDetailsService extends BasePaymentConsentDetailsService<DomesticScheduledPaymentConsentEntity, DomesticScheduledPaymentConsentDetails> {
 
-    public DomesticScheduledPaymentConsentDetailsService(ConsentService<DomesticScheduledPaymentConsentEntity, ?> consentService, ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService, AccountService accountService) {
+    public DomesticScheduledPaymentConsentDetailsService(
+            @Qualifier("internalDomesticScheduledPaymentConsentService") ConsentService<DomesticScheduledPaymentConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            AccountService accountService) {
+
         super(IntentType.PAYMENT_DOMESTIC_SCHEDULED_CONSENT, DomesticScheduledPaymentConsentDetails::new, consentService,
               apiProviderConfiguration, apiClientService, accountService);
     }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/domestic/DomesticStandingOrderConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.domestic;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -29,13 +31,18 @@ import com.forgerock.sapi.gateway.ob.uk.rcs.server.configuration.ApiProviderConf
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.entity.payment.domestic.DomesticStandingOrderConsentEntity;
 import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.forgerock.FRFrequency;
-import com.forgerock.sapi.gateway.uk.common.shared.api.meta.forgerock.FRFrequencyType;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticStandingOrderConsentDetailsService extends BasePaymentConsentDetailsService<DomesticStandingOrderConsentEntity, DomesticStandingOrderConsentDetails> {
 
-    public DomesticStandingOrderConsentDetailsService(ConsentService<DomesticStandingOrderConsentEntity, ?> consentService, ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService, AccountService accountService) {
+    public DomesticStandingOrderConsentDetailsService(
+            @Qualifier("internalDomesticStandingOrderConsentService") ConsentService<DomesticStandingOrderConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            AccountService accountService) {
+
         super(IntentType.PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT, DomesticStandingOrderConsentDetails::new, consentService,
               apiProviderConfiguration, apiClientService, accountService);
     }

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/file/FilePaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/file/FilePaymentConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.file;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -31,9 +33,11 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class FilePaymentConsentDetailsService extends BasePaymentConsentDetailsService<FilePaymentConsentEntity, FilePaymentConsentDetails> {
 
-    public FilePaymentConsentDetailsService(ConsentService<FilePaymentConsentEntity, ?> consentService,
+    public FilePaymentConsentDetailsService(
+            @Qualifier("internalFilePaymentConsentService") ConsentService<FilePaymentConsentEntity, ?> consentService,
             ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
             AccountService accountService) {
 

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalPaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalPaymentConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -31,11 +33,14 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalPaymentConsentDetailsService extends BasePaymentConsentDetailsService<InternationalPaymentConsentEntity, InternationalPaymentConsentDetails> {
 
-    public InternationalPaymentConsentDetailsService(ConsentService<InternationalPaymentConsentEntity, ?> consentService,
-                                                     ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
-                                                     AccountService accountService) {
+    public InternationalPaymentConsentDetailsService(
+            @Qualifier("internalInternationalPaymentConsentService") ConsentService<InternationalPaymentConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            AccountService accountService) {
 
         super(IntentType.PAYMENT_INTERNATIONAL_CONSENT, InternationalPaymentConsentDetails::new, consentService,
                 apiProviderConfiguration, apiClientService, accountService);

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalScheduledPaymentConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalScheduledPaymentConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -31,11 +33,14 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalScheduledPaymentConsentDetailsService extends BasePaymentConsentDetailsService<InternationalScheduledPaymentConsentEntity, InternationalScheduledPaymentConsentDetails> {
 
-    public InternationalScheduledPaymentConsentDetailsService(ConsentService<InternationalScheduledPaymentConsentEntity, ?> consentService,
-                                                              ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
-                                                              AccountService accountService) {
+    public InternationalScheduledPaymentConsentDetailsService(
+            @Qualifier("internalInternationalScheduledPaymentConsentService")  ConsentService<InternationalScheduledPaymentConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            AccountService accountService) {
 
         super(IntentType.PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT, InternationalScheduledPaymentConsentDetails::new, consentService,
                 apiProviderConfiguration, apiClientService, accountService);

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/international/InternationalStandingOrderConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.international;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
@@ -32,11 +34,14 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.forgerock.FRFrequenc
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class InternationalStandingOrderConsentDetailsService extends BasePaymentConsentDetailsService<InternationalStandingOrderConsentEntity, InternationalStandingOrderConsentDetails> {
 
-    public InternationalStandingOrderConsentDetailsService(ConsentService<InternationalStandingOrderConsentEntity, ?> consentService,
-                                                     ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
-                                                     AccountService accountService) {
+    public InternationalStandingOrderConsentDetailsService(
+            @Qualifier("internalInternationalStandingOrderConsentService") ConsentService<InternationalStandingOrderConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
+            AccountService accountService) {
 
         super(IntentType.PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT, InternationalStandingOrderConsentDetails::new, consentService,
                 apiProviderConfiguration, apiClientService, accountService);

--- a/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsService.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/details/payment/vrp/DomesticVRPConsentDetailsService.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rcs.server.api.details.payment.vrp;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsentData;
@@ -30,10 +32,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.repo.service.ConsentService;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 @Component
+@DependsOn({"internalConsentServices"})
 public class DomesticVRPConsentDetailsService extends BasePaymentConsentDetailsService<DomesticVRPConsentEntity, DomesticVrpPaymentConsentDetails> {
 
-    public DomesticVRPConsentDetailsService(ConsentService<DomesticVRPConsentEntity, ?> consentService,
-            ApiProviderConfiguration apiProviderConfiguration, ApiClientServiceClient apiClientService,
+    public DomesticVRPConsentDetailsService(
+            @Qualifier("internalDomesticVRPConsentService") ConsentService<DomesticVRPConsentEntity, ?> consentService,
+            ApiProviderConfiguration apiProviderConfiguration,
+            ApiClientServiceClient apiClientService,
             AccountService accountService) {
 
         super(IntentType.DOMESTIC_VRP_PAYMENT_CONSENT, DomesticVrpPaymentConsentDetails::new, consentService,

--- a/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiControllerRcsConsentStoreTest.java
+++ b/secure-api-gateway-ob-uk-rcs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rcs/server/api/decision/ConsentDecisionApiControllerRcsConsentStoreTest.java
@@ -34,8 +34,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import jakarta.annotation.PostConstruct;
-
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -43,11 +41,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -108,6 +108,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 
+import jakarta.annotation.PostConstruct;
 import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
 import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
 import uk.org.openbanking.datamodel.v3.account.OBRisk2;
@@ -130,6 +131,7 @@ import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFac
 @EnableConfigurationProperties
 @ActiveProfiles("test")
 @SpringBootTest(classes = RCSServerApplicationTestSupport.class, webEnvironment = RANDOM_PORT)
+@DependsOn({"internalConsentServices"})
 public class ConsentDecisionApiControllerRcsConsentStoreTest {
 
     private static final String TEST_API_CLIENT_ID = "test-api-client-1";
@@ -154,33 +156,43 @@ public class ConsentDecisionApiControllerRcsConsentStoreTest {
     private ConsentStoreEnabledIntentTypes consentStoreEnabledIntentTypes;
 
     @Autowired
+    @Qualifier("internalAccountAccessConsentService")
     private AccountAccessConsentService accountAccessConsentService;
 
     @Autowired
+    @Qualifier("internalDomesticPaymentConsentService")
     private DomesticPaymentConsentService domesticPaymentConsentService;
 
     @Autowired
+    @Qualifier("internalDomesticScheduledPaymentConsentService")
     private DomesticScheduledPaymentConsentService domesticScheduledPaymentConsentService;
 
     @Autowired
+    @Qualifier("internalDomesticStandingOrderConsentService")
     private DomesticStandingOrderConsentService domesticStandingOrderConsentService;
 
     @Autowired
+    @Qualifier("internalInternationalPaymentConsentService")
     private InternationalPaymentConsentService internationalPaymentConsentService;
 
     @Autowired
+    @Qualifier("internalInternationalScheduledPaymentConsentService")
     private InternationalScheduledPaymentConsentService internationalScheduledPaymentConsentService;
 
     @Autowired
+    @Qualifier("internalInternationalStandingOrderConsentService")
     private InternationalStandingOrderConsentService internationalStandingOrderConsentService;
 
     @Autowired
+    @Qualifier("internalFilePaymentConsentService")
     private FilePaymentConsentService filePaymentConsentService;
 
     @Autowired
+    @Qualifier("internalDomesticVRPConsentService")
     private DomesticVRPConsentService domesticVRPConsentService;
 
     @Autowired
+    @Qualifier("internalFundsConfirmationConsentService")
     private FundsConfirmationConsentService fundsConfirmationConsentService;
 
     @Autowired


### PR DESCRIPTION
Consents should only be accessed using the OB API version that they were created with or a newer version.

This change adds validation to enforce this logic for consents accessed via the Consent Store API.

Consents that are accessed by the RCS UI (/details and /decision endpoints) are not subject to version requirements and therefore apply no validation.

ApiVersionValidator interface can be implemented to control how version validation is carried out. By default, the
BackwardsCompatibilityApiVersionValidator implementation is used which implements the OB logic.

The validator can be plugged into the BaseConsentService via the apiVersionValidationStrategy hook, this is done using the new ConsentServiceFactory class.

This results in multiple ConsentService objects  being created per consent type, one to handle the internal (no version validation use case) and another per OB API version. To create these services, Spring beans are created and registered dynamically in our configuration classes.

When a ConsentService dependency is needed, the internal or version specific service should be selected by using the `@Qualifier` annotation and supplying the bean name.

The ConsentService beans created have the following naming convention:
- "internal$ConsentServiceInterfaceClassName" e.g. internalAccountAccessConsentService
- "$obApiVersion$ConsentServiceInterfaceClassName" e.g. v3.1.10AccountAccessConsentService

As these beans are being created dynamically, then the`@DependsOn` annotation should be used to ensure that they have been created before dependent components are constructed. The value should be either:
- `@DependsOn({"internalConsentServices"})`
- `@DependsOn({"versionedConsentServices"})`

See the following configuration for further details:
- com.forgerock.sapi.gateway.rcs.consent.store.repo.ConsentStoreConfiguration#internalConsentServices
- com.forgerock.sapi.gateway.rcs.consent.store.api.ConsentStoreApiConfiguration#versionedConsentServices

https://github.com/SecureApiGateway/SecureApiGateway/issues/1493