### PR TITLE
1606: Investigate issues with release when using flatten commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ temp
 *.tgz
 .flattened-pom.xml
 /.flattened-pom.xml
+release.properties
+pom.xml.releaseBackup
+pom.xml.tag

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,14 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-
+    <parent>
+        <groupId>com.forgerock.sapi.gateway</groupId>
+        <artifactId>secure-api-gateway-parent</artifactId>
+        <version>4.0.0</version>
+    </parent>
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
     <version>${revision}</version>
@@ -26,37 +31,23 @@
     <name>secure-api-gateway-ob-uk-rcs</name>
     <description>A UK Open Banking Remote Consent Service for the Secure API Gateway</description>
     <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs.git</url>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten-maven-plugin.version}</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>bom</flattenMode>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
+    <modules>
+        <module>secure-api-gateway-ob-uk-rcs-api</module>
+        <module>secure-api-gateway-ob-uk-rcs-server</module>
+        <module>secure-api-gateway-ob-uk-rcs-cloud-client</module>
+        <module>secure-api-gateway-ob-uk-rcs-consent-store</module>
+    </modules>
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs.git</url>
+        <tag>HEAD</tag>
+    </scm>
+    <properties>
+        <!-- Plugin versions -->
+        <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+        <revision>4.0.1-SNAPSHOT</revision>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <!-- ForgeRock BOM (Bill of Material)-->
@@ -69,26 +60,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <modules>
-        <module>secure-api-gateway-ob-uk-rcs-api</module>
-        <module>secure-api-gateway-ob-uk-rcs-server</module>
-        <module>secure-api-gateway-ob-uk-rcs-cloud-client</module>
-        <module>secure-api-gateway-ob-uk-rcs-consent-store</module>
-    </modules>
-
-    <parent>
-        <groupId>com.forgerock.sapi.gateway</groupId>
-        <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
-    </parent>
-
-    <properties>
-        <!-- Plugin versions -->
-        <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
-        <revision>4.0.1-SNAPSHOT</revision>
-    </properties>
-
     <repositories>
         <repository>
             <id>maven.forgerock.org-community</id>
@@ -110,11 +81,35 @@
             </snapshots>
         </repository>
     </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-    <scm>
-        <connection>scm:git:${project.scm.url}</connection>
-        <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs.git</url>
-        <tag>HEAD</tag>
-    </scm>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.forgerock.sapi.gateway</groupId>
                 <artifactId>secure-api-gateway-ob-uk-common-bom</artifactId>
-                <version>4.0.1-SNAPSHOT</version>
+                <version>4.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-rcs</artifactId>
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.forgerock.sapi.gateway</groupId>
                 <artifactId>secure-api-gateway-ob-uk-common-bom</artifactId>
-                <version>4.0.0</version>
+                <version>4.0.1-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- Reorder pom.xml to align with outputted pom.xml after running flatten:flatten command
- Use resolveCiFriendliesOnly instead of bom
- Add files to .gitignore

When testing locally, got further than before with current format

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1606