### PR TITLE
OPENIG-10460 Fix logback-core version

### DIFF
--- a/secure-api-gateway-ob-uk-rcs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rcs-server/pom.xml
@@ -34,7 +34,6 @@
         <gcrRepo>europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact</gcrRepo>
         <!-- property to run individualy the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-        <logback.version>1.5.25</logback.version>
     </properties>
 
     <dependencies>
@@ -118,13 +117,7 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
-      <!-- ForgeRock Test dependencies -->
+        <!-- ForgeRock Test dependencies -->
         <dependency>
             <groupId>com.forgerock.sapi.gateway</groupId>
             <artifactId>secure-api-gateway-ob-uk-rcs-cloud-client</artifactId>


### PR DESCRIPTION
No longer any need of pinned logback versions. Stick with version now set in IG BOM (corrected to include logback-core).
